### PR TITLE
Use esprima-fb package instead of pointing at github

### DIFF
--- a/lib/parse/extractJavelinSymbols.js
+++ b/lib/parse/extractJavelinSymbols.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var esprima = require('esprima/esprima');
+var esprima = require('esprima-fb');
 var Syntax = esprima.Syntax;
 
 function traverse(node, visitor) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "node-haste"
   },
   "dependencies": {
-    "esprima": "https://github.com/facebook/esprima/tarball/a3e0ea3979eb8d54d8bfade220c272903f928b1e"
+    "esprima-fb": "1001.1001.1000-dev-harmony-fb"
   },
   "jstest": {
     "useAutoMock": false


### PR DESCRIPTION
It's better like this. No tests fail that didn't already (which is a thing we should fix).

I can just commit this directly to avoid a merge commit. Just give me the :thumbsup:
