### PR TITLE
Fix unit tests

### DIFF
--- a/lib/resource/ProjectConfiguration.js
+++ b/lib/resource/ProjectConfiguration.js
@@ -55,7 +55,9 @@ ProjectConfiguration.prototype.getHastePrefix = function() {
 ProjectConfiguration.prototype.getHasteRoots = function() {
   var dirname = path.dirname(this.path);
   if (this.data.haste && this.data.haste.roots) {
-    return this.data.haste.roots.map(path.join.bind(this, dirname));
+    return this.data.haste.roots.map(function(root) {
+      return path.join(dirname, root);
+    });
   }
   return [dirname];
 };


### PR DESCRIPTION
`path.join` is a varargs function and joins all arguments. The `map` call passes
index and full array as further arguments.

Test Plan:
all jasmine tests pass
