### PR TITLE
Add a main.js file so that require("node-haste") will work

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Once scanned it will update the map with the new data.
 ## Example
 
 ```js
-var Haste = require('node-haste/Haste');
-var loaders = require('node-haste/loaders');
+var Haste = require('node-haste').Haste;
+var loaders = require('node-haste').loaders;
 
 // configure haste facade
 var haste = new Haste(

--- a/main.js
+++ b/main.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+exports.Haste = require('./lib/Haste');
+exports.loaders = require('./lib/loaders');

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "haste": {
     "name": "node-haste"
   },
+  "main": "main.js",
   "dependencies": {
     "esprima-fb": "1001.1001.1000-dev-harmony-fb"
   },


### PR DESCRIPTION
Other modules in `lib/` should probably be exported, but I chose to be conservative about what we export for now.
