### PR TITLE
Revert "Use child_process.exec() instead of spawn() in FileFinder"

### DIFF
--- a/lib/FileFinder.js
+++ b/lib/FileFinder.js
@@ -90,7 +90,7 @@ function findNative(scanDirs, extensions, ignore, callback) {
   if(os.platform() == 'win32'){
     return this.find(scanDirs,extensions,ignore,callback);
   }
-  var exec = require('child_process').exec;
+  var spawn = require('child_process').spawn;
   var args = [].concat(scanDirs);
   args.push('-type', 'f');
   extensions.forEach(function(ext, index) {
@@ -98,10 +98,10 @@ function findNative(scanDirs, extensions, ignore, callback) {
       args.push('-o');
     }
     args.push('-iname');
-    args.push(JSON.stringify('*' + ext));
+    args.push('*' + ext);
   });
 
-  var find = exec(['find'].concat(args).join(' '));
+  var find = spawn('find', args);
   var stdout = '';
   find.stdout.setEncoding('utf-8');
   find.stdout.on('data', function(data) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-haste",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "haste": {
     "name": "node-haste"
   },


### PR DESCRIPTION
child_process.exec kills the subprocess after 200 kB of stdout, which is not a
high enough threshold in many cases:
http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback.

This reverts the lib/FileFinder.js changes in commit
40b39985efa7ffb084207dc1a8c1b86bd2c0725c and bumps the package version number.
