### PR TITLE
Don't count empty filename as a found file

### DIFF
--- a/lib/FileFinder.js
+++ b/lib/FileFinder.js
@@ -109,7 +109,8 @@ function findNative(scanDirs, extensions, ignore, callback) {
   });
 
   find.stdout.on('close', function(code) {
-    var lines = stdout.split('\n');
+    // Split by lines, trimming the trailing newline
+    var lines = stdout.trim().split('\n');
     if (ignore) {
       var include = function(x) {
         return !ignore(x);


### PR DESCRIPTION
Previously, we were getting "a.js\nb.js\n" and turning that into ["a.js", "b.js", ""]; now we don't have the extra empty filename.
