### PR TITLE
include jsx as js resource

### DIFF
--- a/lib/loader/JSLoader.js
+++ b/lib/loader/JSLoader.js
@@ -60,7 +60,7 @@ JSLoader.prototype.getResourceTypes = function() {
 };
 
 JSLoader.prototype.getExtensions = function() {
-  return ['.js'];
+  return ['.js', '.jsx'];
 };
 
 
@@ -271,7 +271,8 @@ JSLoader.prototype.loadFromSource =
  * @return {Boolean}
  */
 JSLoader.prototype.matchPath = function(filePath) {
-  return filePath.lastIndexOf('.js') === filePath.length - 3;
+  return filePath.lastIndexOf('.js') === filePath.length - 3 ||
+    filePath.lastIndexOf('.jsx') === filePath.length - 4;
 };
 
 
@@ -463,4 +464,3 @@ JSLoader.prototype.postProcess = function(map, resources, callback) {
 };
 
 module.exports = JSLoader;
-


### PR DESCRIPTION
When enabling coverage, Jest will collect all the relative codes automatically, but not .jsx. It is because resourceMap doesn't include those .jsx files. So I think it may make sense to include .jsx as js resource.
