### PR TITLE
Add support for generic file extension __mocks__

### DIFF
--- a/__tests__/JSMockLoader-test.js
+++ b/__tests__/JSMockLoader-test.js
@@ -39,6 +39,24 @@ describe('JSMockLoader', function() {
     expect(loader.matchPath('a/1.css')).toBe(false);
   });
 
+  it('should match mocks with the specified file extensions', function() {
+    var loader = new JSMockLoader({ extensions: ['.coffee', '.js'] });
+    expect(loader.matchPath('__mocks__/x.js')).toBe(true);
+    expect(loader.matchPath('__mocks__/x.jsx')).toBe(false);
+    expect(loader.matchPath('__mocks__/x.coffee')).toBe(true);
+    expect(loader.matchPath('__mocks__/x.md')).toBe(false);
+    expect(loader.matchPath('__mocks__/x.litcoffee')).toBe(false);
+  });
+
+  it('should match mocks with the default file extension', function() {
+    var loader = new JSMockLoader();
+    expect(loader.matchPath('__mocks__/x.js')).toBe(true);
+    expect(loader.matchPath('__mocks__/x.jsx')).toBe(false);
+    expect(loader.matchPath('__mocks__/x.coffee')).toBe(false);
+    expect(loader.matchPath('__mocks__/x.md')).toBe(false);
+    expect(loader.matchPath('__mocks__/x.litcoffee')).toBe(false);
+  });
+
   var testData = path.join(__dirname, '..', '__test_data__', 'JSMock');
 
   it('should extract dependencies', function() {

--- a/lib/loader/JSMockLoader.js
+++ b/lib/loader/JSMockLoader.js
@@ -27,9 +27,16 @@ var JSMock = require('../resource/JSMock');
 function JSMockLoader(options) {
   ResourceLoader.call(this, options);
 
+  var extensions;
+  if(options && options.extensions){
+    extensions = options.extensions;
+  }else{
+    extensions = ['.js'];
+  }
+
   this.pathRe = this.options.matchSubDirs ?
-    /(?:[\\/]|^)__mocks__[\\/](.+)\.js$/ :
-    /(?:[\\/]|^)__mocks__[\\/]([^\/]+)\.js$/;
+    new RegExp("(?:[\\\\/]|^)__mocks__[\\\\/](.+)(?:\\" + extensions.join("|\\") + ")$") :
+    new RegExp("(?:[\\\\/]|^)__mocks__[\\\\/]([^\\/]+)(?:\\" + extensions.join("|\\") + ")$");
 }
 inherits(JSMockLoader, ResourceLoader);
 JSMockLoader.prototype.path = __filename;
@@ -39,7 +46,7 @@ JSMockLoader.prototype.getResourceTypes = function() {
 };
 
 JSMockLoader.prototype.getExtensions = function() {
-  return ['.js'];
+  return this.options.extensions || ['.js'];
 };
 
 

--- a/lib/loader/JSMockLoader.js
+++ b/lib/loader/JSMockLoader.js
@@ -28,9 +28,9 @@ function JSMockLoader(options) {
   ResourceLoader.call(this, options);
 
   var extensions;
-  if(options && options.extensions){
+  if (options && options.extensions) {
     extensions = options.extensions;
-  }else{
+  } else {
     extensions = ['.js'];
   }
 


### PR DESCRIPTION
This makes the MockLoader match files depending on the options.extensions configuration, falling back to `.js` (which was the previous behavior).

Our application and jest tests are written in CoffeeScript and so we modified haste to be able to write mocks in it as well.