### PR TITLE
Catch dir not existing error

### DIFF
--- a/lib/FileFinder.js
+++ b/lib/FileFinder.js
@@ -34,6 +34,10 @@ function find(scanDirs, extensions, ignore, callback) {
   function readdirRecursive(curDir) {
     activeCalls++;
     fs.readdir(curDir, function(err, names) {
+      if (err) {
+        return throw err;
+      }
+      
       activeCalls--;
 
       for (var i = 0; i < names.length; i++) {


### PR DESCRIPTION
This was giving unhelpful stacks traces when names was empty and err was a thing. 

here we can at least throw the error and see what's hapening.