### PR TITLE
Remove duplicated fields

### DIFF
--- a/lib/ResourceMap.js
+++ b/lib/ResourceMap.js
@@ -25,7 +25,6 @@ function ResourceMap(resources, typeToMap) {
   this.resourceMap = {};
   this.resourcePathMap = {};
   this.typeToMap = typeToMap || {};
-  this.inferredProjectPaths = null;
   resources && resources.forEach(this.addResource, this);
 }
 


### PR DESCRIPTION
ResourceMap.js has duplicated property code `inferredProjectPaths`, remove it.