### PR TITLE
Allow one * at the start of a docblock

### DIFF
--- a/src/DependencyGraph/docblock.js
+++ b/src/DependencyGraph/docblock.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-var docblockRe = /^\s*(\/\*\*(.|\r?\n)*?\*\/)/;
+var docblockRe = /^\s*(\/\*\*?(.|\r?\n)*?\*\/)/;
 
 var ltrimRe = /^\s*/;
 /**


### PR DESCRIPTION
`docblockRe` was requiring two, but `commentStartRe` down below was fine with one. My current project has a custom webpack haste loader that only looks for `provides` and `providesModule` and we have a lot of existing code that has only one * in its docblocks so it seemed easier to relax the restriction here.