### PR TITLE
Improvements for transforms running before dependency extraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-haste",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/node-haste.git"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "graceful-fs": "^4.1.3",
     "json-stable-stringify": "^1.0.1",
     "promise": "^7.1.1",
-    "sane": "^1.3.1"
+    "sane": "^1.3.1",
+    "throat": "^2.0.2"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",

--- a/src/ModuleCache.js
+++ b/src/ModuleCache.js
@@ -3,6 +3,7 @@
 const AssetModule = require('./AssetModule');
 const Package = require('./Package');
 const Module = require('./Module');
+const Polyfill = require('./Polyfill');
 const path = require('fast-path');
 
 class ModuleCache {
@@ -85,6 +86,17 @@ class ModuleCache {
 
     module.__package = packagePath;
     return this.getPackage(packagePath);
+  }
+
+  createPolyfill({file}) {
+    return new Polyfill({
+      file,
+      cache: this._cache,
+      depGraphHelpers: this._depGraphHelpers,
+      fastfs: this._fastfs,
+      moduleCache: this,
+      transformCode: this._transformCode,
+    });
   }
 
   _processFileChange(type, filePath, root) {

--- a/src/Polyfill.js
+++ b/src/Polyfill.js
@@ -4,10 +4,10 @@ const Promise = require('promise');
 const Module = require('./Module');
 
 class Polyfill extends Module {
-  constructor({ path, id, dependencies }) {
-    super({ file: path });
-    this._id = id;
-    this._dependencies = dependencies;
+  constructor(options) {
+    super(options);
+    this._id = options.id;
+    this._dependencies = options.dependencies;
   }
 
   isHaste() {

--- a/src/__tests__/DependencyGraph-test.js
+++ b/src/__tests__/DependencyGraph-test.js
@@ -21,8 +21,8 @@ const mocksPattern = /(?:[\\/]|^)__mocks__[\\/]([^\/]+)\.js$/;
 describe('DependencyGraph', function() {
   let defaults;
 
-  function getOrderedDependenciesAsJSON(dgraph, entry, platform, recursive = true) {
-    return dgraph.getDependencies(entry, platform, recursive)
+  function getOrderedDependenciesAsJSON(dgraph, entryPath, platform, recursive = true) {
+    return dgraph.getDependencies({entryPath, platform, recursive})
       .then(response => response.finalize())
       .then(({ dependencies }) => Promise.all(dependencies.map(dep => Promise.all([
         dep.getName(),
@@ -4110,7 +4110,7 @@ describe('DependencyGraph', function() {
         roots: [root],
       });
 
-      return dgraph.getDependencies('/root/index.js')
+      return dgraph.getDependencies({entryPath: '/root/index.js'})
         .then(response => response.finalize())
         .then(response => {
           expect(response.mocks).toEqual({});
@@ -4140,7 +4140,7 @@ describe('DependencyGraph', function() {
         mocksPattern,
       });
 
-      return dgraph.getDependencies('/root/b.js')
+      return dgraph.getDependencies({entryPath: '/root/b.js'})
         .then(response => response.finalize())
         .then(response => {
           expect(response.mocks).toEqual({

--- a/src/__tests__/Module-test.js
+++ b/src/__tests__/Module-test.js
@@ -251,6 +251,22 @@ describe('Module', () => {
       });
     });
 
+    pit('forwards all additional properties of the result provided by `transformCode`', () => {
+      const mockedResult = {
+        code: exampleCode,
+        arbitrary: 'arbitrary',
+        dependencyOffsets: [12, 764],
+        map: {version: 3},
+        subObject: {foo: 'bar'},
+      };
+      transformCode.mockReturnValue(Promise.resolve(mockedResult));
+      const module = createModule({transformCode});
+
+      return module.read().then((result) => {
+        expect(result).toEqual(jasmine.objectContaining(mockedResult));
+      });
+    });
+
     pit('exposes the transformed code rather than the raw file contents', () => {
       transformCode.mockReturnValue(Promise.resolve({code: exampleCode}));
       const module = createModule({transformCode});
@@ -259,6 +275,12 @@ describe('Module', () => {
           expect(data.code).toBe(exampleCode);
           expect(code).toBe(exampleCode);
         });
+    });
+
+    pit('exposes the raw file contents as `source` property', () => {
+      const module = createModule({transformCode});
+      return module.read()
+        .then(data => expect(data.source).toBe(fileContents));
     });
 
     pit('exposes a source map returned by the transform', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -186,7 +186,13 @@ class DependencyGraph {
     return this.load().then(() => this._moduleCache.getAllModules());
   }
 
-  getDependencies({entryPath, platform, transformOptions, recursive = true}) {
+  getDependencies({
+    entryPath,
+    platform,
+    transformOptions,
+    onProgress,
+    recursive = true,
+  }) {
     return this.load().then(() => {
       platform = this._getRequestPlatform(entryPath, platform);
       const absPath = this._getAbsolutePath(entryPath);
@@ -204,12 +210,13 @@ class DependencyGraph {
 
       const response = new ResolutionResponse();
 
-      return req.getOrderedDependencies(
+      return req.getOrderedDependencies({
         response,
-        this._opts.mocksPattern,
+        mocksPattern: this._opts.mocksPattern,
         transformOptions,
+        onProgress,
         recursive,
-      ).then(() => response);
+      }).then(() => response);
     });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -165,8 +165,10 @@ class DependencyGraph {
    * Returns a promise with the direct dependencies the module associated to
    * the given entryPath has.
    */
-  getShallowDependencies(entryPath) {
-    return this._moduleCache.getModule(entryPath).getDependencies();
+  getShallowDependencies(entryPath, transformOptions) {
+    return this._moduleCache
+      .getModule(entryPath)
+      .getDependencies(transformOptions);
   }
 
   getFS() {
@@ -184,7 +186,7 @@ class DependencyGraph {
     return this.load().then(() => this._moduleCache.getAllModules());
   }
 
-  getDependencies(entryPath, platform, recursive = true) {
+  getDependencies({entryPath, platform, transformOptions, recursive = true}) {
     return this.load().then(() => {
       platform = this._getRequestPlatform(entryPath, platform);
       const absPath = this._getAbsolutePath(entryPath);
@@ -205,6 +207,7 @@ class DependencyGraph {
       return req.getOrderedDependencies(
         response,
         this._opts.mocksPattern,
+        transformOptions,
         recursive,
       ).then(() => response);
     });
@@ -279,6 +282,9 @@ class DependencyGraph {
     });
   }
 
+  createPolyfill(options) {
+    return this._moduleCache.createPolyfill(options);
+  }
 }
 
 Object.assign(DependencyGraph, {


### PR DESCRIPTION
- passes through transform options when getting dependencies
- passes back all properties provided by a custom transform
- `ModuleCache` can create `Polyfill` objects that are completly operational
- `ResolutionRequest` parallelizes dependency extraction instead of running it serially
