### PR TITLE
Fix providesModuleNodeModules behavior to be more deterministic.

### DIFF
--- a/src/DependencyGraph/DependencyGraphHelpers.js
+++ b/src/DependencyGraph/DependencyGraphHelpers.js
@@ -1,4 +1,4 @@
- /**
+/**
  * Copyright (c) 2015-present, Facebook, Inc.
  * All rights reserved.
  *
@@ -8,31 +8,102 @@
  */
 'use strict';
 
+const fs = require('fs');
 const path = require('../fastpath');
 
-const NODE_MODULES = path.sep + 'node_modules' + path.sep;
+const NODE_MODULES_DIR = path.sep + 'node_modules' + path.sep;
 
 class DependencyGraphHelpers {
-  constructor({ providesModuleNodeModules, assetExts }) {
-    this._providesModuleNodeModules = providesModuleNodeModules;
+  constructor({
+    roots = [],
+    providesModuleNodeModules = [],
+    assetExts = [],
+  }) {
+    this._hasteRegex = buildHasteRegex(
+      this._resolveHastePackages(providesModuleNodeModules, roots)
+    );
     this._assetExts = assetExts;
   }
 
+  /**
+   * An item in the `providesModuleNodeModule` array is an object containing two keys:
+   *  * 'name' - the package name
+   *  * 'parent' - if a string, it's the name of the parent package of the module in
+   *  the dep tree. If null, it signifies that we should look for this package at
+   *  the top level of the module tree.
+   *
+   * We try to resolve the specified module...but if we can't, we fallback to looking
+   * in 'node_modules/[package name]' (this satisfies use cases where the actual
+   * 'react-native' package is one of the root dirs, such as when we run tests
+   * or examples).
+   */
+  _resolveHastePackages(packages, roots) {
+    const packagePathForPackage = ({ name, parent }, rootDir) => {
+      let packagePath;
+      if (parent) {
+        if (!Array.isArray(parent)) {
+          parent = [parent];
+        }
+        parent.push(name);
+        packagePath = rootDir +
+          NODE_MODULES_DIR +
+          parent.join(NODE_MODULES_DIR);
+      } else {
+        packagePath = rootDir + NODE_MODULES_DIR + name;
+      }
+
+      if (packagePath.endsWith(path.sep)) {
+        return packagePath.slice(0, -1);
+      } else {
+        return packagePath;
+      }
+    };
+
+    const hastePackages = [];
+    packages.forEach(p => {
+      roots.forEach(rootDir => {
+        let name, parent;
+        if (typeof p === 'string') {
+          name = p;
+          parent = null;
+        } else {
+          name = p.name;
+          parent = p.parent;
+        }
+        const packagePath = packagePathForPackage({ name, parent }, rootDir);
+        try {
+          const stats = fs.statSync(packagePath);
+          if (stats && stats.isDirectory()) {
+            hastePackages.push(packagePath);
+          }
+        } catch (e) {
+          // if we don't find the package, let's just default to node_modules/[package name]
+          hastePackages.push(packagePathForPackage({ name }, rootDir));
+        }
+      });
+    });
+    return hastePackages;
+  }
+
+  /**
+   * This method has three possible outcomes:
+   *
+   * 1) A file is not in 'node_modules' at all (some type of file in the project).
+   * 2) The file is in 'node_modules', and it's contained in one of the
+   * 'providesModuleNodeModules' packages.
+   * 3) It's in 'node_modules' but not in a 'providesModuleNodeModule' package,
+   * so it's just a normal node_module.
+   *
+   * This method uses a regex to do the directory testing, rather than for loop
+   * and `indexOf` in order to get perf wins.
+   */
   isNodeModulesDir(file) {
-    const index = file.lastIndexOf(NODE_MODULES);
+    const index = file.indexOf(NODE_MODULES_DIR);
     if (index === -1) {
       return false;
     }
 
-    const parts = file.substr(index + 14).split(path.sep);
-    const dirs = this._providesModuleNodeModules;
-    for (let i = 0; i < dirs.length; i++) {
-      if (parts.indexOf(dirs[i]) > -1) {
-        return false;
-      }
-    }
-
-    return true;
+    return !this._hasteRegex.test(file);
   }
 
   isAssetFile(file) {
@@ -42,6 +113,31 @@ class DependencyGraphHelpers {
   extname(name) {
     return path.extname(name).substr(1);
   }
+}
+
+/**
+ * Given a list of directories, build a regex that takes the form:
+ * 	^((?![module's node_modules dir])[module dir])|
+ * 	 ((?![next module's node_modules dir])[next module dir])|...
+ *
+ * This is an alternative to looping through any of the providesModuleNodeModules
+ * during `isNodeModulesDir`, which is run tens of thousands of times in a typical
+ * project. A regex is much faster in this use-case.
+ */
+function buildHasteRegex(dirs) {
+  const dirRegexes = [];
+  dirs.forEach(dir => {
+    const dirRegex = '((?!' +
+      escapeRegExp(dir + NODE_MODULES_DIR) + ')' +
+      escapeRegExp(dir + path.sep) + ')';
+    dirRegexes.push(dirRegex);
+  });
+
+  return new RegExp('^' + dirRegexes.join('|'));
+}
+
+function escapeRegExp(str) {
+  return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
 }
 
 module.exports = DependencyGraphHelpers;

--- a/src/DependencyGraph/__tests__/DependencyGraphHelpers-test.js
+++ b/src/DependencyGraph/__tests__/DependencyGraphHelpers-test.js
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+jest.autoMockOff();
+
+jest.mock('fs');
+
+const DependencyGraphHelpers = require('../DependencyGraphHelpers');
+const fs = require('graceful-fs');
+
+describe('DependencyGraphHelpers', function() {
+  it('should properly resolve haste packages', function() {
+    var root = '/root';
+    _setMockFilesystem();
+
+    const helpers = new DependencyGraphHelpers({});
+    const hastePackageDirs = helpers._resolveHastePackages([
+      { name: 'haste-fbjs', parent: 'react-native' },
+      'react-haste', // handle just a string as input
+      { name: 'react-native' },
+    ], [root]);
+
+    expect(hastePackageDirs).toEqual([
+      '/root/node_modules/react-native/node_modules/haste-fbjs',
+      '/root/node_modules/react-haste',
+      '/root/node_modules/react-native',
+    ]);
+  });
+
+  it('should correctly determined whether a file is a node_module or haste module', function() {
+    var root = '/root';
+    _setMockFilesystem();
+
+    const helpers = new DependencyGraphHelpers({
+      providesModuleNodeModules: [
+        { name: 'haste-fbjs', parent: 'react-native' },
+        { name: 'react-haste' },
+      ],
+      roots: [root],
+    });
+
+    expect(
+      helpers.isNodeModulesDir('/root/index.js')
+    ).toBe(false);
+
+    expect(
+      helpers.isNodeModulesDir('/root/node_modules/haste-fbjs/main.js')
+    ).toBe(true);
+
+    expect(
+      helpers.isNodeModulesDir('/root/node_modules/react-native/node_modules/haste-fbjs/main.js')
+    ).toBe(false);
+  });
+
+  function _setMockFilesystem() {
+    fs.__setMockFilesystem({
+      'root': {
+        'index.js': [
+          '/**',
+          ' * @providesModule index',
+          ' */',
+          'require("shouldWork");',
+        ].join('\n'),
+        'node_modules': {
+          // A peer version of haste-fbjs
+          'haste-fbjs': {
+            'package.json': JSON.stringify({
+              name: 'haste-fbjs',
+              main: 'main.js',
+            }),
+            'main.js': [
+              '/**',
+              ' * @providesModule shouldWork',
+              ' */',
+            ].join('\n'),
+          },
+          'react-native': {
+            'package.json': JSON.stringify({
+              name: 'react-native',
+              main: 'main.js',
+            }),
+            'node_modules': {
+              // the version of haste-fbjs that
+              // we specified to be a `providesModuleNodeModule`
+              'haste-fbjs': {
+                'package.json': JSON.stringify({
+                  name: 'haste-fbjs',
+                  main: 'main.js',
+                }),
+                'main.js': [
+                  '/**',
+                  ' * @providesModule shouldWork',
+                  ' */',
+                ].join('\n'),
+              },
+            },
+          },
+        },
+      },
+    });
+  }
+});

--- a/src/__mocks__/graceful-fs.js
+++ b/src/__mocks__/graceful-fs.js
@@ -112,6 +112,43 @@ fs.stat.mockImpl(function(filepath, callback) {
   }
 });
 
+fs.statSync.mockImpl(function(filepath) {
+  var node;
+  node = getToNode(filepath);
+
+  var mtime = {
+    getTime: function() {
+      return Math.ceil(Math.random() * 10000000);
+    },
+  };
+
+  if (node.SYMLINK) {
+    return fs.statSync(node.SYMLINK);
+  }
+
+  if (node && typeof node === 'object') {
+    return {
+      isDirectory: function() {
+        return true;
+      },
+      isSymbolicLink: function() {
+        return false;
+      },
+      mtime: mtime,
+    };
+  } else {
+    return {
+      isDirectory: function() {
+        return false;
+      },
+      isSymbolicLink: function() {
+        return false;
+      },
+      mtime: mtime,
+    };
+  }
+});
+
 const noop = () => {};
 fs.open.mockImpl(function(path) {
   const callback = arguments[arguments.length - 1] || noop;

--- a/src/__tests__/DependencyGraph-test.js
+++ b/src/__tests__/DependencyGraph-test.js
@@ -89,14 +89,14 @@ describe('DependencyGraph', function() {
       cache: new Cache(),
       fileWatcher,
       providesModuleNodeModules: [
-        'haste-fbjs',
-        'react-haste',
-        'react-native',
+        { name: 'haste-fbjs', parent: 'react-native' },
+        { name: 'react-haste' },
+        { name: 'react-native' },
         // Parse requires AsyncStorage. They will
         // change that to require('react-native') which
         // should work after this release and we can
         // remove it from here.
-        'parse',
+        { name: 'parse' },
       ],
       platforms: ['ios', 'android'],
       shouldThrowOnUnresolvedErrors: () => false,
@@ -2868,6 +2868,85 @@ describe('DependencyGraph', function() {
       });
     });
 
+    pit('should not have a naming collision error when two versions of the same module exist', function() {
+      var root = '/root';
+      fs.__setMockFilesystem({
+        'root': {
+          'index.js': [
+            '/**',
+            ' * @providesModule index',
+            ' */',
+            'require("shouldWork");',
+          ].join('\n'),
+          'node_modules': {
+            // A peer version of haste-fbjs
+            'haste-fbjs': {
+              'package.json': JSON.stringify({
+                name: 'haste-fbjs',
+                main: 'main.js',
+              }),
+              'main.js': [
+                '/**',
+                ' * @providesModule shouldWork',
+                ' */',
+              ].join('\n'),
+            },
+            'react-native': {
+              'package.json': JSON.stringify({
+                name: 'react-native',
+                main: 'main.js',
+              }),
+              'node_modules': {
+                // the version of haste-fbjs that
+                // we specified to be a `providesModuleNodeModule`
+                'haste-fbjs': {
+                  'package.json': JSON.stringify({
+                    name: 'haste-fbjs',
+                    main: 'main.js',
+                  }),
+                  'main.js': [
+                    '/**',
+                    ' * @providesModule shouldWork',
+                    ' */',
+                  ].join('\n'),
+                },
+              },
+            },
+          },
+        },
+      });
+
+      var dgraph = new DependencyGraph({
+        ...defaults,
+        roots: [root],
+      });
+
+      return getOrderedDependenciesAsJSON(dgraph, '/root/index.js').then(function(deps) {
+        expect(deps)
+          .toEqual([
+            {
+              id: 'index',
+              path: '/root/index.js',
+              dependencies: ['shouldWork'],
+              isAsset: false,
+              isAsset_DEPRECATED: false,
+              isJSON: false,
+              isPolyfill: false,
+              resolution: undefined,
+            },
+            {
+              id: 'shouldWork',
+              path: '/root/node_modules/react-native/node_modules/haste-fbjs/main.js',
+              dependencies: [],
+              isAsset: false,
+              isAsset_DEPRECATED: false,
+              isJSON: false,
+              isPolyfill: false,
+              resolution: undefined,
+            },
+          ]);
+      });
+    });
 
     pit('should ignore modules it cant find (assumes own require system)', function() {
       // For example SourceMap.js implements it's own require system.


### PR DESCRIPTION
--- Relates to https://github.com/facebook/react-native/pull/5985 ---

Currently, the `providesModuleNodeModules` option allows for specifying an array of package names, that the packager will look for within node_modules, no matter how deep they're nested, and treat them as packages that use the `@providesModule` pragma.

In reality, this is not actually the behavior we want.

npm, because of how it handles dependencies, can do all kinds of arbitrary nesting of packages when `npm install` is run. This causes a problem for how we deal with `providesModuleNodeModules`. Specifically...take `fbjs`. Currently, React Native relies on using the Haste version of `fbjs` (will be resolved in #5084). Thus if npm installs multiple copies of fbjs...which is a very common thing for it to do (as can be seen by this list of issues: https://github.com/facebook/react-native/issues?utf8=%E2%9C%93&q=naming+collision+detected), we get into a state where the packager fails and says that we have a naming collision.

Really, the behavior we want is for the packager to treat only a *single* copy of a given package, that we specify in the `Resolver` in the `providesModuleNodeModules` option, as the package that it uses when trying to resolve Haste modules.

This PR provides that behavior, by changing `providesModuleNodeModules` from a list of strings to a list of objects that have a `name` key, specifying the package name, as well as a `parent` key. If `parent` is null, it will look for the package at the top level (directly under `node_modules`). If `parent` is specified, it will use the package that is nested under that parent as the Haste module.

To anyone who reads this PR and is familiar with the differences between npm2 and npm3 -- this solution works under both, given the fact that we are now shipping the NPM Shrinkwrap file with React Native when it's installed through `npm`. In both the npm2 and npm3 case, node_modules specified by RN's package.json are nested underneath `react-native` in node_modules, thus allowing us to specify, for example, that we want to use React Native's copy of `fbjs` (not any other copy that may be installed) as the module used by the packager to resolve any `requires` that reference a module in `fbjs`.