### PR TITLE
Filewatcher could be empty.

### DIFF
--- a/src/fastfs.js
+++ b/src/fastfs.js
@@ -62,7 +62,10 @@ class Fastfs extends EventEmitter {
       if (activity) {
         activity.endEvent(fastfsActivity);
       }
-      this._fileWatcher.on('all', this._processFileChange.bind(this));
+      
+      if (this._fileWatcher) {
+        this._fileWatcher.on('all', this._processFileChange.bind(this));
+      }
     });
   }
 


### PR DESCRIPTION
When use DependencyGraph alone to get hasteMap data, filewatcher is not must. Add a pre-check with filewatcher avoid throw a error.