### PR TITLE
Fix Windows compatibility

### DIFF
--- a/src/DependencyGraph/DependencyGraphHelpers.js
+++ b/src/DependencyGraph/DependencyGraphHelpers.js
@@ -10,6 +10,8 @@
 
 const path = require('fast-path');
 
+const NODE_MODULES = path.sep + 'node_modules' + path.sep;
+
 class DependencyGraphHelpers {
   constructor({ providesModuleNodeModules, assetExts }) {
     this._providesModuleNodeModules = providesModuleNodeModules;
@@ -17,7 +19,7 @@ class DependencyGraphHelpers {
   }
 
   isNodeModulesDir(file) {
-    const index = file.lastIndexOf('/node_modules/');
+    const index = file.lastIndexOf(NODE_MODULES);
     if (index === -1) {
       return false;
     }

--- a/src/DependencyGraph/HasteMap.js
+++ b/src/DependencyGraph/HasteMap.js
@@ -13,6 +13,7 @@ const Promise = require('promise');
 
 const GENERIC_PLATFORM = 'generic';
 const NATIVE_PLATFORM = 'native';
+const PACKAGE_JSON = path.sep + 'package.json';
 
 class HasteMap {
   constructor({
@@ -37,7 +38,7 @@ class HasteMap {
         if (this._extensions.indexOf(path.extname(filePath).substr(1)) !== -1) {
           promises.push(this._processHasteModule(filePath));
         }
-        if (filePath.endsWith('/package.json')) {
+        if (filePath.endsWith(PACKAGE_JSON)) {
           promises.push(this._processHastePackage(filePath));
         }
       }

--- a/src/fastfs.js
+++ b/src/fastfs.js
@@ -62,7 +62,7 @@ class Fastfs extends EventEmitter {
       if (activity) {
         activity.endEvent(fastfsActivity);
       }
-      
+
       if (this._fileWatcher) {
         this._fileWatcher.on('all', this._processFileChange.bind(this));
       }


### PR DESCRIPTION
There were 3 issues that broke node haste on windows.

1. `fast-path.normalize` returns a lowercase drive letter which is different from node's `path.normalize` and caused a bunch of issues everywhere. To fix it I wrapped path in a module and return the node one on Windows. This allows keeping the fast-path optimization on mac and linux. I'll try to get it fixed upstream so this is no longer necessary. 

2. `'/package.json'` string in HasteMap.js needs to be `path.sep +
'package.json'`

3. `'/node_modules/'` string in DependencyGraphHelpers.js needs to be `path.sep + 'node_modules' + path.sep`

Test plan
Run the UIExplorer example in react-native on both Windows and Mac. Had to make a few tweaks to RN so it works with node-haste 2.1.1