### PR TITLE
Update watchman detection and cleanup FileWatcher.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-haste",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/node-haste.git"

--- a/src/FileWatcher/__tests__/FileWatcher-test.js
+++ b/src/FileWatcher/__tests__/FileWatcher-test.js
@@ -13,24 +13,19 @@ jest
   .dontMock('events')
   .dontMock('../')
   .setMock('child_process', {
-    exec: (cmd, cb) => cb(null, '/usr/bin/watchman'),
+    execSync: () => '/usr/bin/watchman',
   });
 
 const sane = require('sane');
 
 describe('FileWatcher', () => {
   let WatchmanWatcher;
-  let NodeWatcher;
   let FileWatcher;
   let config;
 
   beforeEach(() => {
     WatchmanWatcher = sane.WatchmanWatcher;
     WatchmanWatcher.prototype.once.mockImplementation(
-      (type, callback) => callback()
-    );
-    NodeWatcher = sane.NodeWatcher;
-    NodeWatcher.prototype.once.mockImplementation(
       (type, callback) => callback()
     );
 
@@ -46,19 +41,10 @@ describe('FileWatcher', () => {
   });
 
   pit('gets the watcher instance when ready', () => {
-    const fileWatcher = new FileWatcher(config, {useWatchman: true});
+    const fileWatcher = new FileWatcher(config);
     return fileWatcher.getWatchers().then(watchers => {
       watchers.forEach(watcher => {
         expect(watcher instanceof WatchmanWatcher).toBe(true);
-      });
-    });
-  });
-
-  pit('gets the node watcher if watchman is disabled', () => {
-    const fileWatcher = new FileWatcher(config, {useWatchman: false});
-    return fileWatcher.getWatchers().then(watchers => {
-      watchers.forEach(watcher => {
-        expect(watcher instanceof NodeWatcher).toBe(true);
       });
     });
   });
@@ -68,7 +54,7 @@ describe('FileWatcher', () => {
     WatchmanWatcher.prototype.on.mockImplementation((type, callback) => {
       cb = callback;
     });
-    const fileWatcher = new FileWatcher(config, {useWatchman: true});
+    const fileWatcher = new FileWatcher(config);
     const handler = jest.genMockFn();
     fileWatcher.on('all', handler);
     return fileWatcher.getWatchers().then(watchers => {
@@ -79,7 +65,7 @@ describe('FileWatcher', () => {
   });
 
   pit('ends the watcher', () => {
-    const fileWatcher = new FileWatcher(config, {useWatchman: true});
+    const fileWatcher = new FileWatcher(config);
     WatchmanWatcher.prototype.close.mockImplementation(callback => callback());
 
     return fileWatcher.end().then(() => {

--- a/src/crawlers/index.js
+++ b/src/crawlers/index.js
@@ -3,25 +3,9 @@
 const nodeCrawl = require('./node');
 const watchmanCrawl = require('./watchman');
 
-function checkWatchman(fileWatcher) {
-  if (!fileWatcher) {
-    return Promise.resolve(false);
-  }
-
-  return fileWatcher.isWatchman().then(isWatchman => {
-    if (!isWatchman) {
-      return false;
-    }
-
-    // Make sure we're dealing with a version of watchman
-    // that's using `watch-project`
-    // TODO(amasad): properly expose (and document) used sane internals.
-    return fileWatcher.getWatchers().then(([watcher]) => !!watcher.watchProjectInfo.root);
-  });
-}
-
 function crawl(roots, options) {
-  return checkWatchman(options.fileWatcher).then(
+  const {fileWatcher} = options;
+  return (fileWatcher ? fileWatcher.isWatchman() : Promise.resolve(false)).then(
     isWatchman => isWatchman ? watchmanCrawl(roots, options) : nodeCrawl(roots, options)
   );
 }

--- a/src/crawlers/watchman.js
+++ b/src/crawlers/watchman.js
@@ -3,6 +3,8 @@
 const Promise = require('promise');
 const path = require('fast-path');
 
+const watchmanURL = 'https://facebook.github.io/watchman/docs/troubleshooting.html';
+
 function watchmanRecReadDir(roots, {ignore, fileWatcher, exts}) {
   const files = [];
   return Promise.all(
@@ -56,7 +58,15 @@ function watchmanRecReadDir(roots, {ignore, fileWatcher, exts}) {
           });
         })
       );
-    }).then(() => files);
+    }).then(
+      () => files,
+      error => {
+        throw new Error(
+          `Watchman error: ${error.message.trim()}. Make sure watchman ` +
+          `is running for this project. See ${watchmanURL}.`
+        );
+      }
+    );
 }
 
 function isDescendant(root, child) {


### PR DESCRIPTION
This updates watchman detection slightly:

* synchronously detect if watchman is available or not
* if watchman is available but can't be used, throw a better error message
* remove the silly `useWatchman` logic in the FileWatcher, we can check from the outside
* remove the `watch-project` check which is part since watchman 3.1 (released last August), cc @mkonicek for react-native release notes?