### PR TITLE
Add a DependencyGraph test that simulates a windows environment

### DIFF
--- a/src/__mocks__/graceful-fs.js
+++ b/src/__mocks__/graceful-fs.js
@@ -170,7 +170,12 @@ fs.__setMockFilesystem = function(object) {
 };
 
 function getToNode(filepath) {
-  var parts = filepath.split('/');
+  // Ignore the drive for Windows paths.
+  if (filepath.match(/^[a-zA-Z]:\\/)) {
+    filepath = filepath.substring(2);
+  }
+
+  var parts = filepath.split(/[\/\\]/);
   if (parts[0] !== '') {
     throw new Error('Make sure all paths are absolute.');
   }

--- a/src/__tests__/DependencyGraph-test.js
+++ b/src/__tests__/DependencyGraph-test.js
@@ -2119,6 +2119,86 @@ describe('DependencyGraph', function() {
     });
   });
 
+  describe('get sync dependencies on Windows', function() {
+    const realPlatform = process.platform;
+    beforeEach(function() {
+      process.platform = 'win32';
+    });
+
+    afterEach(function() {
+      process.platform = realPlatform;
+    });
+
+    pit('should get dependencies', function() {
+      process.platform = 'win32';
+      const root = 'C:\\root';
+      fs.__setMockFilesystem({
+        'root': {
+          'index.js': [
+            '/**',
+            ' * @providesModule index',
+            ' */',
+            'require("a")',
+          ].join('\n'),
+          'a.js': [
+            '/**',
+            ' * @providesModule a',
+            ' */',
+            'require("b")',
+          ].join('\n'),
+          'b.js': [
+            '/**',
+            ' * @providesModule b',
+            ' */',
+          ].join('\n'),
+        },
+      });
+
+      var dgraph = new DependencyGraph({
+        ...defaults,
+        roots: [root],
+      });
+      return getOrderedDependenciesAsJSON(dgraph, 'C:\\root\\index.js').then((deps) => {
+        expect(deps)
+          .toEqual([
+            {
+              id: 'index',
+              path: 'C:\\root\\index.js',
+              dependencies: ['a'],
+              isAsset: false,
+              isAsset_DEPRECATED: false,
+              isJSON: false,
+              isPolyfill: false,
+              resolution: undefined,
+              resolveDependency: undefined,
+            },
+            {
+              id: 'a',
+              path: 'C:\\root\\a.js',
+              dependencies: ['b'],
+              isAsset: false,
+              isAsset_DEPRECATED: false,
+              isJSON: false,
+              isPolyfill: false,
+              resolution: undefined,
+              resolveDependency: undefined,
+            },
+            {
+              id: 'b',
+              path: 'C:\\root\\b.js',
+              dependencies: [],
+              isAsset: false,
+              isAsset_DEPRECATED: false,
+              isJSON: false,
+              isPolyfill: false,
+              resolution: undefined,
+              resolveDependency: undefined,
+            },
+          ]);
+      });
+    });
+  });
+
   describe('node_modules', function() {
     pit('should work with nested node_modules', function() {
       var root = '/root';


### PR DESCRIPTION
I ported one of the DependencyGraph test to use Windows-like paths and set `process.platform` to `win32`. I also had to make a few tweaks to the fs mock to support these paths.

The test will fail until #38 and #41 land which is actually a good thing :)

Let me know if you have ideas for other tests.

cc @cpojer