### PR TITLE
Better compatibility with browserify modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "absolute-path": "^0.0.0",
+    "browserify": "^13.0.0",
     "debug": "^2.2.0",
     "denodeify": "^1.2.1",
     "graceful-fs": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "main": "lib/index.js",
   "dependencies": {
     "absolute-path": "^0.0.0",
-    "browserify": "^13.0.0",
     "debug": "^2.2.0",
     "denodeify": "^1.2.1",
     "graceful-fs": "^4.1.3",

--- a/src/Package.js
+++ b/src/Package.js
@@ -2,6 +2,7 @@
 
 const isAbsolutePath = require('absolute-path');
 const path = require('./fastpath');
+const builtins = require('browserify/lib/builtins');
 
 class Package {
 
@@ -19,17 +20,14 @@ class Package {
       if (typeof replacements === 'string') {
         return path.join(this.root, replacements);
       }
-
       let main = json.main || 'index';
-
-      if (replacements && typeof replacements === 'object') {
-        main = replacements[main] ||
-          replacements[main + '.js'] ||
-          replacements[main + '.json'] ||
-          replacements[main.replace(/(\.js|\.json)$/, '')] ||
-          main;
+      // cut of the extension, if any
+      main = main.replace(/(\.js|\.json)$/, '');
+      // find a possible replacement
+      var replacement = this.getReplacement(main, replacements);
+      if (replacement !== undefined) {
+        main = replacement;
       }
-
       return path.join(this.root, main);
     });
   }
@@ -50,34 +48,65 @@ class Package {
     this._cache.invalidate(this.path);
   }
 
+  getReplacement(name, replacements) {
+    if (typeof replacements !== 'object') {
+      return undefined;
+    }
+    const relPath = './' + path.relative(this.root, name);
+    const relName = './' + name;
+    const checks = [
+      replacements[name],
+      replacements[name + '.js'],
+      replacements[name + '.json'],
+      replacements[relName],
+      replacements[relName + '.js'],
+      replacements[relName + '.json'],
+      replacements[relPath],
+      replacements[relPath + '.js'],
+      replacements[relPath + '.json']
+    ];
+    const matches = checks.filter(check => check !== undefined);
+    if (matches[0] === false) {
+      return false;
+    }
+    return matches[0] || undefined;
+  }
+
   redirectRequire(name) {
     return this.read().then(json => {
-      var replacements = getReplacements(json);
-
-      if (!replacements || typeof replacements !== 'object') {
+      let replacements = getReplacements(json);
+      if (typeof replacements === 'string') {
+        replacements = {
+          [json.main || 'index']: replacements
+        };
+      }
+      let replacement = this.getReplacement(name, replacements);
+      // no replacement
+      if (replacement === undefined) {
+        // could stil be requiring a builtin
+        if (builtins[name]) {
+          var redirect = path.relative(this.root, builtins[name]);
+          // cut off node_modules if the builtin is required
+          // from the "index" of the react-native project
+          if (redirect.slice(0, 13) === 'node_modules/') {
+            redirect = redirect.slice(13);
+          }
+          return redirect;
+        }
         return name;
       }
-
-      if (name[0] !== '/') {
-        return replacements[name] || name;
+      // replacement is false boolean
+      if (replacement === false) {
+        // find path to _empty.js
+        let emptyPath = require.resolve('browserify/lib/_empty.js');
+        return './' + path.relative(this.root, emptyPath);
       }
-
-      if (!isAbsolutePath(name)) {
-        throw new Error(`Expected ${name} to be absolute path`);
+      // replacement is other module (or absolute path?)
+      if (replacement[0] !== '.') {
+        return replacement;
       }
-
-      const relPath = './' + path.relative(this.root, name);
-      const redirect = replacements[relPath] ||
-              replacements[relPath + '.js'] ||
-              replacements[relPath + '.json'];
-      if (redirect) {
-        return path.join(
-          this.root,
-          redirect
-        );
-      }
-
-      return name;
+      // replacement is relative path
+      return path.join(this.root, replacement);
     });
   }
 
@@ -93,7 +122,7 @@ class Package {
 
 function getReplacements(pkg) {
   return pkg['react-native'] == null
-    ? pkg.browser
+    ? (pkg.browser == null ? pkg.browserify : pkg.browser)
     : pkg['react-native'];
 }
 

--- a/src/_empty.js
+++ b/src/_empty.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */


### PR DESCRIPTION
This pull request does a couple of things

1) Checks for the browserify field (some old packages still depend on it)
https://github.com/facebook/node-haste/pull/46/files#diff-9103f1ac13c3018f7108b3e6bbf20df4R125

2) Handles `false` in replacements, shimming it with `_empty.js` as browserify does
https://github.com/facebook/node-haste/pull/46/files#diff-9103f1ac13c3018f7108b3e6bbf20df4R99

3) Add function to get a replacement for a file that is also used in `getMain` (with more path checks)
https://github.com/facebook/node-haste/pull/46/files#diff-9103f1ac13c3018f7108b3e6bbf20df4R51

It checks for `name`, `'./' + name` and  `'./' + path.relative(this.root, name);`
And we should probably add `path.relative(this.root, name);` to that as well?

4) Cherry on the cake, shims browserify builtins
https://github.com/facebook/node-haste/pull/46/files#diff-9103f1ac13c3018f7108b3e6bbf20df4R87

I tested these changes by requiring some modules and inspecting the generated bundle while on the latest tag of react-native (0.20) and later copied them over to my node-haste fork.

Simply said, It very likely contains bugs and is probably incompatible with the current master branch.

Tests will follow soon, but here it is anyways!

There is room for improvement and help is welcome.
## Questions

1) If the path starts with node_modules, it doesn't work anymore, see my "hotfix" here
https://github.com/facebook/node-haste/pull/46/files#diff-9103f1ac13c3018f7108b3e6bbf20df4R91

2) Not every module that is (removed /) shimmed with false is replaced.
It seems to work fine when the replacement is "at the root" but not when "nested deeper", see the examples of what I mean by that:

root:

``` json
"react-native": {
  "./something.js": false
}
```

nested deeper:

``` json
"react-native": {
  "./lib/something.js": false
}
```

https://github.com/facebook/node-haste/pull/46/files#diff-9103f1ac13c3018f7108b3e6bbf20df4R102
## Todos
- [ ] Adding tests
- [ ] Figuring out how to move forward with browserify builtins / global replacements
- [ ] Figuring out what causes question 1
- [ ] Figuring out what causes question 2
