### PR TITLE
Fix relative entry paths

### DIFF
--- a/src/__tests__/DependencyGraph-test.js
+++ b/src/__tests__/DependencyGraph-test.js
@@ -181,6 +181,39 @@ describe('DependencyGraph', function() {
       });
     });
 
+    pit('should resolve relative entry path', function() {
+      var root = '/root';
+      fs.__setMockFilesystem({
+        'root': {
+          'index.js': [
+            '/**',
+            ' * @providesModule index',
+            ' */',
+          ].join('\n'),
+        },
+      });
+
+      var dgraph = new DependencyGraph({
+        ...defaults,
+        roots: [root],
+      });
+      return getOrderedDependenciesAsJSON(dgraph, 'index.js').then(function(deps) {
+        expect(deps)
+          .toEqual([
+            {
+              id: 'index',
+              path: '/root/index.js',
+              dependencies: [],
+              isAsset: false,
+              isAsset_DEPRECATED: false,
+              isJSON: false,
+              isPolyfill: false,
+              resolution: undefined,
+            },
+          ]);
+      });
+    });
+
     pit('should get shallow dependencies', function() {
       var root = '/root';
       fs.__setMockFilesystem({

--- a/src/index.js
+++ b/src/index.js
@@ -195,7 +195,7 @@ class DependencyGraph {
   }) {
     return this.load().then(() => {
       platform = this._getRequestPlatform(entryPath, platform);
-      const absPath = path.resolve(entryPath);
+      const absPath = this._getAbsolutePath(entryPath);
       const req = new ResolutionRequest({
         platform,
         preferNativePlatform: this._opts.preferNativePlatform,


### PR DESCRIPTION
Revert this change (https://github.com/facebook/node-haste/commit/9673f86c5f78fff56be2d38c5698af65ac816295#diff-1fdf421c05c1140f6d71444ea2b27638L198) as it caused relative entry paths to not work properly and add a test for that regression. The issue happened in react-native it didn't resolve the app entry point properly. See https://github.com/facebook/react-native/pull/6260#issuecomment-192088787 for more context.


Any reason why this was changed?

cc @cpojer @davidaurelio @yaycmyk 