### PR TITLE
Fix node-haste when an empty `providesModuleNodeModules` field is given

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-haste",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/node-haste.git"

--- a/src/DependencyGraph/DependencyGraphHelpers.js
+++ b/src/DependencyGraph/DependencyGraphHelpers.js
@@ -19,9 +19,10 @@ class DependencyGraphHelpers {
     providesModuleNodeModules = [],
     assetExts = [],
   }) {
-    this._hasteRegex = buildHasteRegex(
-      this._resolveHastePackages(providesModuleNodeModules, roots)
-    );
+    const list = providesModuleNodeModules;
+    this._hasteRegex = list && list.length ? buildHasteRegex(
+      this._resolveHastePackages(list, roots)
+    ) : null;
     this._assetExts = assetExts;
   }
 
@@ -103,7 +104,7 @@ class DependencyGraphHelpers {
       return false;
     }
 
-    return !this._hasteRegex.test(file);
+    return this._hasteRegex ? !this._hasteRegex.test(file) : true;
   }
 
   isAssetFile(file) {


### PR DESCRIPTION
This is the default in Jest and started breaking the Jest 0.9.0 release when 2.6.0 was tagged. Going forward, Jest should probably use `~` instead, although no one is really to blame here – this was just unfortunate :)

Originally found here: https://github.com/facebook/jest/issues/771