### PR TITLE
Simplify comment regexes + support all valid line endings

### DIFF
--- a/src/lib/__tests__/extractRequires-test.js
+++ b/src/lib/__tests__/extractRequires-test.js
@@ -57,7 +57,7 @@ describe('extractRequires', () => {
     ].join('\n');
 
     expect(extractRequires(code)).toEqual({
-      code: '',
+      code: '\n',
       deps: {sync: []},
     });
   });
@@ -71,7 +71,22 @@ describe('extractRequires', () => {
     ].join('\r\n');
 
     expect(extractRequires(code)).toEqual({
-      code: '',
+      code: '\r\n',
+      deps: {sync: []},
+    });
+  });
+
+  it('should ignore requires in comments with unicode line endings', () => {
+    const code = [
+      '// const module1 = require("module1");\u2028',
+      '// const module1 = require("module2");\u2029',
+      '/*\u2028',
+      'const module2 = require("module3");\u2029',
+      ' */',
+    ].join('');
+
+    expect(extractRequires(code)).toEqual({
+      code: '\u2028\u2029',
       deps: {sync: []},
     });
   });

--- a/src/lib/extractRequires.js
+++ b/src/lib/extractRequires.js
@@ -13,8 +13,8 @@ const replacePatterns = require('./replacePatterns');
 /**
  * Extract all required modules from a `code` string.
  */
-const blockCommentRe = /\/\*(.|\n|\r\n)*?\*\//g;
-const lineCommentRe = /\/\/.+(\n|\r\n|$)/g;
+const blockCommentRe = /\/\*[^]*?\*\//g;
+const lineCommentRe = /\/\/.*/g;
 function extractRequires(code) {
   const cache = Object.create(null);
   var deps = {


### PR DESCRIPTION
By not listing all valid line endings explicetely, we can simplify the regular expressions for comments and make them more correct.