### PR TITLE
Add support for the Ubuntu platform.

### DIFF
--- a/src/AssetModule.js
+++ b/src/AssetModule.js
@@ -6,7 +6,7 @@ const getAssetDataFromName = require('./lib/getAssetDataFromName');
 class AssetModule extends Module {
   constructor(...args) {
     super(...args);
-    const { resolution, name, type } = getAssetDataFromName(this.path);
+    const { resolution, name, type } = getAssetDataFromName(this.path, this._platforms);
     this.resolution = resolution;
     this._name = name;
     this._type = type;

--- a/src/AssetModule_DEPRECATED.js
+++ b/src/AssetModule_DEPRECATED.js
@@ -6,7 +6,7 @@ const getAssetDataFromName = require('./lib/getAssetDataFromName');
 class AssetModule_DEPRECATED extends Module {
   constructor(...args) {
     super(...args);
-    const {resolution, name} = getAssetDataFromName(this.path);
+    const {resolution, name} = getAssetDataFromName(this.path, this._platforms);
     this.resolution = resolution;
     this.name = name;
   }
@@ -36,7 +36,7 @@ class AssetModule_DEPRECATED extends Module {
   }
 
   resolution() {
-    return getAssetDataFromName(this.path).resolution;
+    return getAssetDataFromName(this.path, this._platforms).resolution;
   }
 
 }

--- a/src/DependencyGraph/DeprecatedAssetMap.js
+++ b/src/DependencyGraph/DeprecatedAssetMap.js
@@ -23,6 +23,7 @@ class DeprecatedAssetMap {
     helpers,
     activity,
     enabled,
+    platforms,
   }) {
     if (roots == null || roots.length === 0 || !enabled) {
       this._disabled = true;
@@ -33,6 +34,7 @@ class DeprecatedAssetMap {
     this._map = Object.create(null);
     this._assetExts = assetExts;
     this._activity = activity;
+    this._platforms = platforms;
 
     if (!this._disabled) {
       this._fastfs = new Fastfs(
@@ -95,7 +97,7 @@ class DeprecatedAssetMap {
         debug('Conflicting assets', name);
       }
 
-      this._map[name] = new AssetModule_DEPRECATED({ file });
+      this._map[name] = new AssetModule_DEPRECATED({ file, platforms: this._platforms });
     }
   }
 

--- a/src/DependencyGraph/HasteMap.js
+++ b/src/DependencyGraph/HasteMap.js
@@ -21,12 +21,14 @@ class HasteMap {
     moduleCache,
     preferNativePlatform,
     helpers,
+    platforms,
   }) {
     this._extensions = extensions;
     this._fastfs = fastfs;
     this._moduleCache = moduleCache;
     this._preferNativePlatform = preferNativePlatform;
     this._helpers = helpers;
+    this._platforms = platforms;
   }
 
   build() {
@@ -125,7 +127,7 @@ class HasteMap {
     }
 
     const moduleMap = this._map[name];
-    const modulePlatform = getPlatformExtension(mod.path) || GENERIC_PLATFORM;
+    const modulePlatform = getPlatformExtension(mod.path, this._platforms) || GENERIC_PLATFORM;
     const existingModule = moduleMap[modulePlatform];
 
     if (existingModule && existingModule.path !== mod.path) {

--- a/src/DependencyGraph/ResolutionRequest.js
+++ b/src/DependencyGraph/ResolutionRequest.js
@@ -25,6 +25,7 @@ const getDependencies = throat(
 class ResolutionRequest {
   constructor({
     platform,
+    platforms,
     preferNativePlatform,
     entryPath,
     hasteMap,
@@ -35,6 +36,7 @@ class ResolutionRequest {
     shouldThrowOnUnresolvedErrors,
   }) {
     this._platform = platform;
+    this._platforms = platforms;
     this._preferNativePlatform = preferNativePlatform;
     this._entryPath = entryPath;
     this._hasteMap = hasteMap;
@@ -344,7 +346,7 @@ class ResolutionRequest {
           );
         }
 
-        const {name, type} = getAssetDataFromName(potentialModulePath);
+        const {name, type} = getAssetDataFromName(potentialModulePath, this._platforms);
 
         let pattern = '^' + name + '(@[\\d\\.]+x)?';
         if (this._platform != null) {

--- a/src/Module.js
+++ b/src/Module.js
@@ -25,6 +25,7 @@ class Module {
     extractor = extractRequires,
     transformCode,
     depGraphHelpers,
+    platforms,
   }) {
     if (!isAbsolutePath(file)) {
       throw new Error('Expected file to be absolute path but got ' + file);
@@ -39,6 +40,7 @@ class Module {
     this._extractor = extractor;
     this._transformCode = transformCode;
     this._depGraphHelpers = depGraphHelpers;
+    this._platforms = platforms;
   }
 
   isHaste() {

--- a/src/ModuleCache.js
+++ b/src/ModuleCache.js
@@ -14,6 +14,7 @@ class ModuleCache {
     extractRequires,
     transformCode,
     depGraphHelpers,
+    platforms,
   }) {
     this._moduleCache = Object.create(null);
     this._packageCache = Object.create(null);
@@ -22,6 +23,7 @@ class ModuleCache {
     this._extractRequires = extractRequires;
     this._transformCode = transformCode;
     this._depGraphHelpers = depGraphHelpers;
+    this._platforms = platforms;
 
     fastfs.on('change', this._processFileChange.bind(this));
   }
@@ -36,6 +38,7 @@ class ModuleCache {
         extractor: this._extractRequires,
         transformCode: this._transformCode,
         depGraphHelpers: this._depGraphHelpers,
+        platforms: this._platforms,
       });
     }
     return this._moduleCache[filePath];
@@ -52,6 +55,7 @@ class ModuleCache {
         fastfs: this._fastfs,
         moduleCache: this,
         cache: this._cache,
+        platforms: this._platforms,
       });
     }
     return this._moduleCache[filePath];

--- a/src/__tests__/DependencyGraph-test.js
+++ b/src/__tests__/DependencyGraph-test.js
@@ -3237,6 +3237,7 @@ describe('DependencyGraph', function() {
 
       var dgraph = new DependencyGraph({
         ...defaults,
+        platforms: ['ios', 'android', 'web'],
         roots: [root],
       });
       return getOrderedDependenciesAsJSON(dgraph, '/root/index.ios.js').then(function(deps) {

--- a/src/index.js
+++ b/src/index.js
@@ -112,6 +112,7 @@ class DependencyGraph {
       extractRequires: this._opts.extractRequires,
       transformCode: this._opts.transformCode,
       depGraphHelpers: this._helpers,
+      platforms: this._opts.platforms,
     });
 
     this._hasteMap = new HasteMap({
@@ -120,6 +121,7 @@ class DependencyGraph {
       moduleCache: this._moduleCache,
       preferNativePlatform: this._opts.preferNativePlatform,
       helpers: this._helpers,
+      platforms: this._opts.platforms,
     });
 
     this._deprecatedAssetMap = new DeprecatedAssetMap({
@@ -131,6 +133,7 @@ class DependencyGraph {
       assetExts: this._opts.assetExts,
       activity: this._opts.activity,
       enabled: this._opts.enableAssetMap,
+      platforms: this._opts.platforms,
     });
 
     this._loading = Promise.all([
@@ -198,6 +201,7 @@ class DependencyGraph {
       const absPath = this._getAbsolutePath(entryPath);
       const req = new ResolutionRequest({
         platform,
+        platforms: this._opts.platforms,
         preferNativePlatform: this._opts.preferNativePlatform,
         entryPath: absPath,
         deprecatedAssetMap: this._deprecatedAssetMap,
@@ -226,10 +230,7 @@ class DependencyGraph {
 
   _getRequestPlatform(entryPath, platform) {
     if (platform == null) {
-      platform = getPlatformExtension(entryPath);
-      if (platform == null || this._opts.platforms.indexOf(platform) === -1) {
-        platform = null;
-      }
+      platform = getPlatformExtension(entryPath, this._opts.platforms);
     } else if (this._opts.platforms.indexOf(platform) === -1) {
       throw new Error('Unrecognized platform: ' + platform);
     }

--- a/src/lib/__tests__/getPlatformExtension-test.js
+++ b/src/lib/__tests__/getPlatformExtension-test.js
@@ -22,4 +22,12 @@ describe('getPlatformExtension', function() {
     expect(getPlatformExtension('/b/c/a@1.5x.lol.png')).toBe(null);
     expect(getPlatformExtension('/b/c/a.lol.png')).toBe(null);
   });
+
+  it('should optionally accept supported platforms', function() {
+    expect(getPlatformExtension('a.ios.js', ['ios'])).toBe('ios');
+    expect(getPlatformExtension('a.android.js', ['android'])).toBe('android');
+    expect(getPlatformExtension('/b/c/a.ios.js', ['ios', 'android'])).toBe('ios');
+    expect(getPlatformExtension('a.ios.js', ['ubuntu'])).toBe(null);
+    expect(getPlatformExtension('a.ubuntu.js', ['ubuntu'])).toBe('ubuntu');
+  });
 });

--- a/src/lib/getAssetDataFromName.js
+++ b/src/lib/getAssetDataFromName.js
@@ -11,9 +11,9 @@
 const path = require('../fastpath');
 const getPlatformExtension = require('./getPlatformExtension');
 
-function getAssetDataFromName(filename) {
+function getAssetDataFromName(filename, platforms) {
   const ext = path.extname(filename);
-  const platformExt = getPlatformExtension(filename);
+  const platformExt = getPlatformExtension(filename, platforms);
 
   let pattern = '@([\\d\\.]+)x';
   if (platformExt != null) {

--- a/src/lib/getPlatformExtension.js
+++ b/src/lib/getPlatformExtension.js
@@ -8,22 +8,21 @@
  */
 'use strict';
 
-const SUPPORTED_PLATFORM_EXTS = {
-  android: true,
-  ios: true,
-  web: true,
-  ubuntu: true,
-};
+const SUPPORTED_PLATFORM_EXTS = [
+  'android',
+  'ios',
+  'web',
+];
 
 // Extract platform extension: index.ios.js -> ios
-function getPlatformExtension(file) {
+function getPlatformExtension(file, platforms = SUPPORTED_PLATFORM_EXTS) {
   const last = file.lastIndexOf('.');
   const secondToLast = file.lastIndexOf('.', last - 1);
   if (secondToLast === -1) {
     return null;
   }
   const platform = file.substring(secondToLast + 1, last);
-  return SUPPORTED_PLATFORM_EXTS[platform] ? platform : null;
+  return platforms.indexOf(platform) !== -1 ? platform : null;
 }
 
 module.exports = getPlatformExtension;

--- a/src/lib/getPlatformExtension.js
+++ b/src/lib/getPlatformExtension.js
@@ -12,6 +12,7 @@ const SUPPORTED_PLATFORM_EXTS = {
   android: true,
   ios: true,
   web: true,
+  ubuntu: true,
 };
 
 // Extract platform extension: index.ios.js -> ios


### PR DESCRIPTION
Hi,

I'd like to add support for the Ubuntu platform and this patch represents the simplest way to achieve that. 

I did look at the uses of getPlatformExtension, and it may be possible to provide a list of platforms to be used for validation - rather than or in conjunction with the static set, but some uses are free of any platform related context. To properly implement the more general change might cut deeper than would be liked.

It would be great if you could take this as is, but I am also happy to work with you all to a goal of supporting other platforms.
