### PR TITLE
Improvements

### DIFF
--- a/src/DependencyGraph/ResolutionResponse.js
+++ b/src/DependencyGraph/ResolutionResponse.js
@@ -25,6 +25,10 @@ class ResolutionResponse {
       mainModuleId = this.mainModuleId,
       mocks = this.mocks,
     } = properties;
+
+    const numPrependedDependencies = dependencies === this.dependencies
+      ? this.numPrependedDependencies : 0;
+
     return Object.assign(
       new this.constructor({transformOptions: this.transformOptions}),
       this,
@@ -32,6 +36,7 @@ class ResolutionResponse {
         dependencies,
         mainModuleId,
         mocks,
+        numPrependedDependencies,
       },
     );
   }

--- a/src/lib/__tests__/getInverseDependencies-test.js
+++ b/src/lib/__tests__/getInverseDependencies-test.js
@@ -13,7 +13,7 @@ jest.dontMock('../getInverseDependencies');
 const getInverseDependencies = require('../getInverseDependencies');
 
 describe('getInverseDependencies', () => {
-  pit('', () => {
+  it('', () => {
     const module1 = createModule('module1', ['module2', 'module3']);
     const module2 = createModule('module2', ['module3', 'module4']);
     const module3 = createModule('module3', ['module4']);
@@ -33,13 +33,16 @@ describe('getInverseDependencies', () => {
       },
     };
 
-    return getInverseDependencies(resolutionResponse).then(dependencies =>
-      expect(dependencies).toEqual({
-        module2: ['module1'],
-        module3: ['module1', 'module2'],
-        module4: ['module2', 'module3'],
-      })
-    );
+    const dependencies = getInverseDependencies(resolutionResponse);
+    const actual = // jest can't compare maps and sets
+      Array.from(dependencies.entries())
+        .map(([key, value]) => [key, Array.from(value)]);
+
+    expect(actual).toEqual([
+      [module2, [module1]],
+      [module3, [module1, module2]],
+      [module4, [module2, module3]],
+    ]);
   });
 });
 


### PR DESCRIPTION
- `ResolutionResponse#copy` will reset `numPrependedDependencies` when overwriting dependencies
- `getInverseDependencies` returns a `Map` of modules to `Set` instances of modules