### PR TITLE
Use where instead of which on windows to properly detect watchman

### DIFF
--- a/src/FileWatcher/index.js
+++ b/src/FileWatcher/index.js
@@ -17,10 +17,8 @@ const MAX_WAIT_TIME = 120000;
 
 const detectWatcherClass = () => {
   try {
-    const out = execSync('which watchman');
-    if (out.length !== 0) {
-      return sane.WatchmanWatcher;
-    }
+    execSync('watchman version', {stdio: 'ignore'});
+    return sane.WatchmanWatcher;
   } catch (e) {}
   return sane.NodeWatcher;
 };


### PR DESCRIPTION
The FileWatcher didn't detect watchman properly on windows since it relied on the `which` command. The windows equivalent is `where`. It didn't cause any real issue since it falls back on the NodeWatcher but it keeps printing an annoying error in the console.

**Test plan**
Tested on windows that it properly uses watchman if present using the windows built in `where` command.