### PR TITLE
Make the order of sub-dependencies deterministic.

### DIFF
--- a/src/lib/AsyncTaskGroup.js
+++ b/src/lib/AsyncTaskGroup.js
@@ -1,0 +1,28 @@
+ /**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+module.exports = class AsyncTaskGroup {
+  constructor() {
+    this._runningTasks = new Set();
+    this._resolve = null;
+    this.done = new Promise(resolve => this._resolve = resolve);
+  }
+
+  start(taskHandle) {
+    this._runningTasks.add(taskHandle);
+  }
+
+  end(taskHandle) {
+    const runningTasks = this._runningTasks;
+    if (runningTasks.delete(taskHandle) && runningTasks.size === 0) {
+      this._resolve();
+    }
+  }
+};

--- a/src/lib/MapWithDefaults.js
+++ b/src/lib/MapWithDefaults.js
@@ -1,0 +1,30 @@
+ /**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+module.exports = function MapWithDefaults(factory, iterable) {
+  // This can't be `MapWithDefaults extends Map`, b/c the way babel transforms
+  // super calls in constructors: Map.call(this, iterable) throws for native
+  // Map objects in node 4+.
+  // TODO(davidaurelio) switch to a transform that does not transform classes
+  // and super calls, and change this into a class
+
+  const map = iterable ? new Map(iterable) : new Map();
+  const {get} = map;
+  map.get = key => {
+    if (map.has(key)) {
+      return get.call(map, key);
+    }
+
+    const value = factory(key);
+    map.set(key, value);
+    return value;
+  };
+  return map;
+};


### PR DESCRIPTION
This makes the order of dependencies deterministic, if modules have a common set of subdependencies.

In the dependency tree
```
├── a
│   ├── b
│   └── c
└── d
    ├── b
    └── c
```

The order of dependencies did depend on whether `a` or `d` finished scanning their dependencies first.

It could either be `a, b, c, d` or `a, d, b, c`. This change guarantees a depth-first order, for this tree that would be `a, b, c, d`