### PR TITLE
Added extra fs mocks

### DIFF
--- a/src/__mocks__/graceful-fs.js
+++ b/src/__mocks__/graceful-fs.js
@@ -12,7 +12,9 @@ const fs = jest.genMockFromModule('fs');
 const noop = () => {};
 
 function asyncCallback(cb) {
-  return () => setImmediate(() => cb.apply(this, arguments));
+  return function() {
+    setImmediate(() => cb.apply(this, arguments));
+  };
 }
 
 const mtime = {

--- a/src/__mocks__/graceful-fs.js
+++ b/src/__mocks__/graceful-fs.js
@@ -11,9 +11,9 @@
 const fs = jest.genMockFromModule('fs');
 const noop = () => {};
 
-const asyncCallback = (cb) => function() {
-  setImmediate(() => cb.apply(this, arguments));
-};
+function asyncCallback(cb) {
+  return () => setImmediate(() => cb.apply(this, arguments));
+}
 
 const mtime = {
   getTime: () => Math.ceil(Math.random() * 10000000),
@@ -111,14 +111,8 @@ fs.statSync.mockImpl((filepath) => {
     return fs.statSync(node.SYMLINK);
   }
 
-  let isDirectory = false;
-
-  if (node && typeof node === 'object') {
-    isDirectory = true;
-  }
-
   return {
-    isDirectory: () => isDirectory,
+    isDirectory: () => node && typeof node === 'object',
     isSymbolicLink: () => false,
     mtime,
   };
@@ -135,13 +129,8 @@ fs.lstatSync.mockImpl((filepath) => {
     };
   }
 
-  let isDirectory = false;
-  if (node && typeof node === 'object') {
-    isDirectory = true;
-  }
-
   return {
-    isDirectory: () => isDirectory,
+    isDirectory: () => node && typeof node === 'object',
     isSymbolicLink: () => false,
     mtime,
   };

--- a/src/__mocks__/graceful-fs.js
+++ b/src/__mocks__/graceful-fs.js
@@ -126,31 +126,25 @@ fs.statSync.mockImpl(function(filepath) {
   };
 
   if (node.SYMLINK) {
-    fs.statSync(node.SYMLINK, callback);
+    fs.statSync(node.SYMLINK);
     return;
   }
 
+  var isDirectory = false;
+
   if (node && typeof node === 'object') {
-    return {
-      isDirectory: function() {
-        return true;
-      },
-      isSymbolicLink: function() {
-        return false;
-      },
-      mtime: mtime,
-    };
-  } else {
-    return {
-      isDirectory: function() {
-        return false;
-      },
-      isSymbolicLink: function() {
-        return false;
-      },
-      mtime: mtime,
-    };
+    isDirectory = true
   }
+
+  return {
+    isDirectory: function() {
+      return true;
+    },
+    isSymbolicLink: function() {
+      return false;
+    },
+    mtime: mtime,
+  };
 });
 
 fs.lstatSync.mockImpl(function(filepath) {

--- a/src/__mocks__/graceful-fs.js
+++ b/src/__mocks__/graceful-fs.js
@@ -30,6 +30,10 @@ fs.realpath.mockImpl(function(filepath, callback) {
   callback(null, filepath);
 });
 
+fs.readdirSync.mockImpl(function(filepath) {
+  return Object.keys(getToNode(filepath));
+});
+
 fs.readdir.mockImpl(function(filepath, callback) {
   callback = asyncCallback(callback);
   var node;
@@ -109,6 +113,87 @@ fs.stat.mockImpl(function(filepath, callback) {
       },
       mtime: mtime,
     });
+  }
+});
+
+fs.statSync.mockImpl(function(filepath) {
+  var node = getToNode(filepath);
+
+  var mtime = {
+    getTime: function() {
+      return Math.ceil(Math.random() * 10000000);
+    },
+  };
+
+  if (node.SYMLINK) {
+    fs.statSync(node.SYMLINK, callback);
+    return;
+  }
+
+  if (node && typeof node === 'object') {
+    return {
+      isDirectory: function() {
+        return true;
+      },
+      isSymbolicLink: function() {
+        return false;
+      },
+      mtime: mtime,
+    };
+  } else {
+    return {
+      isDirectory: function() {
+        return false;
+      },
+      isSymbolicLink: function() {
+        return false;
+      },
+      mtime: mtime,
+    };
+  }
+});
+
+fs.lstatSync.mockImpl(function(filepath) {
+  var node = getToNode(filepath);
+
+  var mtime = {
+    getTime: function() {
+      return Math.ceil(Math.random() * 10000000);
+    },
+  };
+
+  if (node.SYMLINK) {
+    return {
+      isDirectory: function() {
+        return false;
+      },
+      isSymbolicLink: function() {
+        return true;
+      },
+      mtime: mtime,
+    };
+  }
+
+  if (node && typeof node === 'object') {
+    return {
+      isDirectory: function() {
+        return true;
+      },
+      isSymbolicLink: function() {
+        return false;
+      },
+      mtime: mtime,
+    };
+  } else {
+    return {
+      isDirectory: function() {
+        return false;
+      },
+      isSymbolicLink: function() {
+        return false;
+      },
+      mtime: mtime,
+    };
   }
 });
 


### PR DESCRIPTION
To make `glob.sync` work with `node-haste`, we need to mock some additional `fs` methods:
- lstatSync
- statSync
- readdirSync

cc @cpojer 