### PR TITLE
Optionally specify available platforms.

### DIFF
--- a/src/AssetModule.js
+++ b/src/AssetModule.js
@@ -4,9 +4,9 @@ const Module = require('./Module');
 const getAssetDataFromName = require('./lib/getAssetDataFromName');
 
 class AssetModule extends Module {
-  constructor(args) {
+  constructor(args, platforms) {
     super(args);
-    const { resolution, name, type } = getAssetDataFromName(this.path, this._platforms);
+    const { resolution, name, type } = getAssetDataFromName(this.path, platforms);
     this.resolution = resolution;
     this._name = name;
     this._type = type;

--- a/src/AssetModule.js
+++ b/src/AssetModule.js
@@ -6,7 +6,7 @@ const getAssetDataFromName = require('./lib/getAssetDataFromName');
 class AssetModule extends Module {
   constructor(args) {
     super(args);
-    const { resolution, name, type } = getAssetDataFromName(this.path);
+    const { resolution, name, type } = getAssetDataFromName(this.path, this._platforms);
     this.resolution = resolution;
     this._name = name;
     this._type = type;

--- a/src/AssetModule_DEPRECATED.js
+++ b/src/AssetModule_DEPRECATED.js
@@ -6,7 +6,7 @@ const getAssetDataFromName = require('./lib/getAssetDataFromName');
 class AssetModule_DEPRECATED extends Module {
   constructor(...args) {
     super(...args);
-    const {resolution, name} = getAssetDataFromName(this.path);
+    const {resolution, name} = getAssetDataFromName(this.path, this._platforms);
     this.resolution = resolution;
     this.name = name;
   }
@@ -36,7 +36,7 @@ class AssetModule_DEPRECATED extends Module {
   }
 
   resolution() {
-    return getAssetDataFromName(this.path).resolution;
+    return getAssetDataFromName(this.path, this._platforms).resolution;
   }
 
 }

--- a/src/AssetModule_DEPRECATED.js
+++ b/src/AssetModule_DEPRECATED.js
@@ -4,11 +4,12 @@ const Module = require('./Module');
 const getAssetDataFromName = require('./lib/getAssetDataFromName');
 
 class AssetModule_DEPRECATED extends Module {
-  constructor(...args) {
-    super(...args);
-    const {resolution, name} = getAssetDataFromName(this.path, this._platforms);
+  constructor(args, platforms) {
+    super(args);
+    const {resolution, name} = getAssetDataFromName(this.path, platforms);
     this.resolution = resolution;
     this.name = name;
+    this.platforms = platforms;
   }
 
   isHaste() {
@@ -36,7 +37,7 @@ class AssetModule_DEPRECATED extends Module {
   }
 
   resolution() {
-    return getAssetDataFromName(this.path, this._platforms).resolution;
+    return getAssetDataFromName(this.path, this.platforms).resolution;
   }
 
 }

--- a/src/DependencyGraph/DeprecatedAssetMap.js
+++ b/src/DependencyGraph/DeprecatedAssetMap.js
@@ -23,6 +23,7 @@ class DeprecatedAssetMap {
     helpers,
     activity,
     enabled,
+    platforms,
   }) {
     if (roots == null || roots.length === 0 || !enabled) {
       this._disabled = true;
@@ -33,6 +34,7 @@ class DeprecatedAssetMap {
     this._map = Object.create(null);
     this._assetExts = assetExts;
     this._activity = activity;
+    this._platforms = platforms;
 
     if (!this._disabled) {
       this._fastfs = new Fastfs(
@@ -95,7 +97,7 @@ class DeprecatedAssetMap {
         debug('Conflicting assets', name);
       }
 
-      this._map[name] = new AssetModule_DEPRECATED({ file });
+      this._map[name] = new AssetModule_DEPRECATED({ file, platforms: this._platforms });
     }
   }
 

--- a/src/DependencyGraph/DeprecatedAssetMap.js
+++ b/src/DependencyGraph/DeprecatedAssetMap.js
@@ -97,7 +97,7 @@ class DeprecatedAssetMap {
         debug('Conflicting assets', name);
       }
 
-      this._map[name] = new AssetModule_DEPRECATED({ file, platforms: this._platforms });
+      this._map[name] = new AssetModule_DEPRECATED({ file }, this._platforms);
     }
   }
 

--- a/src/DependencyGraph/HasteMap.js
+++ b/src/DependencyGraph/HasteMap.js
@@ -21,12 +21,14 @@ class HasteMap {
     moduleCache,
     preferNativePlatform,
     helpers,
+    platforms,
   }) {
     this._extensions = extensions;
     this._fastfs = fastfs;
     this._moduleCache = moduleCache;
     this._preferNativePlatform = preferNativePlatform;
     this._helpers = helpers;
+    this._platforms = platforms;
   }
 
   build() {
@@ -125,7 +127,7 @@ class HasteMap {
     }
 
     const moduleMap = this._map[name];
-    const modulePlatform = getPlatformExtension(mod.path) || GENERIC_PLATFORM;
+    const modulePlatform = getPlatformExtension(mod.path, this._platforms) || GENERIC_PLATFORM;
     const existingModule = moduleMap[modulePlatform];
 
     if (existingModule && existingModule.path !== mod.path) {

--- a/src/DependencyGraph/ResolutionRequest.js
+++ b/src/DependencyGraph/ResolutionRequest.js
@@ -27,6 +27,7 @@ const getDependencies = throat(
 class ResolutionRequest {
   constructor({
     platform,
+    platforms,
     preferNativePlatform,
     entryPath,
     hasteMap,
@@ -37,6 +38,7 @@ class ResolutionRequest {
     shouldThrowOnUnresolvedErrors,
   }) {
     this._platform = platform;
+    this._platforms = platforms;
     this._preferNativePlatform = preferNativePlatform;
     this._entryPath = entryPath;
     this._hasteMap = hasteMap;
@@ -386,7 +388,7 @@ class ResolutionRequest {
           );
         }
 
-        const {name, type} = getAssetDataFromName(potentialModulePath);
+        const {name, type} = getAssetDataFromName(potentialModulePath, this._platforms);
 
         let pattern = '^' + name + '(@[\\d\\.]+x)?';
         if (this._platform != null) {

--- a/src/Module.js
+++ b/src/Module.js
@@ -25,7 +25,6 @@ class Module {
     extractor = extractRequires,
     transformCode,
     depGraphHelpers,
-    platforms,
   }) {
     if (!isAbsolutePath(file)) {
       throw new Error('Expected file to be absolute path but got ' + file);
@@ -40,7 +39,6 @@ class Module {
     this._extractor = extractor;
     this._transformCode = transformCode;
     this._depGraphHelpers = depGraphHelpers;
-    this._platforms = platforms;
   }
 
   isHaste() {

--- a/src/Module.js
+++ b/src/Module.js
@@ -25,6 +25,7 @@ class Module {
     extractor = extractRequires,
     transformCode,
     depGraphHelpers,
+    platforms,
   }) {
     if (!isAbsolutePath(file)) {
       throw new Error('Expected file to be absolute path but got ' + file);
@@ -39,6 +40,7 @@ class Module {
     this._extractor = extractor;
     this._transformCode = transformCode;
     this._depGraphHelpers = depGraphHelpers;
+    this._platforms = platforms;
   }
 
   isHaste() {

--- a/src/ModuleCache.js
+++ b/src/ModuleCache.js
@@ -14,6 +14,7 @@ class ModuleCache {
     extractRequires,
     transformCode,
     depGraphHelpers,
+    platforms,
     assetDependencies,
   }) {
     this._moduleCache = Object.create(null);
@@ -23,6 +24,7 @@ class ModuleCache {
     this._extractRequires = extractRequires;
     this._transformCode = transformCode;
     this._depGraphHelpers = depGraphHelpers;
+    this._platforms = platforms;
     this._assetDependencies = assetDependencies;
 
     fastfs.on('change', this._processFileChange.bind(this));
@@ -38,6 +40,7 @@ class ModuleCache {
         extractor: this._extractRequires,
         transformCode: this._transformCode,
         depGraphHelpers: this._depGraphHelpers,
+        platforms: this._platforms,
       });
     }
     return this._moduleCache[filePath];
@@ -54,6 +57,7 @@ class ModuleCache {
         fastfs: this._fastfs,
         moduleCache: this,
         cache: this._cache,
+        platforms: this._platforms,
         dependencies: this._assetDependencies,
       });
     }

--- a/src/ModuleCache.js
+++ b/src/ModuleCache.js
@@ -14,9 +14,8 @@ class ModuleCache {
     extractRequires,
     transformCode,
     depGraphHelpers,
-    platforms,
     assetDependencies,
-  }) {
+  }, platforms) {
     this._moduleCache = Object.create(null);
     this._packageCache = Object.create(null);
     this._fastfs = fastfs;
@@ -40,7 +39,6 @@ class ModuleCache {
         extractor: this._extractRequires,
         transformCode: this._transformCode,
         depGraphHelpers: this._depGraphHelpers,
-        platforms: this._platforms,
       });
     }
     return this._moduleCache[filePath];
@@ -57,9 +55,8 @@ class ModuleCache {
         fastfs: this._fastfs,
         moduleCache: this,
         cache: this._cache,
-        platforms: this._platforms,
         dependencies: this._assetDependencies,
-      });
+      }, this._platforms);
     }
     return this._moduleCache[filePath];
   }

--- a/src/__tests__/DependencyGraph-test.js
+++ b/src/__tests__/DependencyGraph-test.js
@@ -3091,6 +3091,7 @@ describe('DependencyGraph', function() {
 
       var dgraph = new DependencyGraph({
         ...defaults,
+        platforms: ['ios', 'android', 'web'],
         roots: [root],
       });
       return getOrderedDependenciesAsJSON(dgraph, '/root/index.ios.js').then(function(deps) {

--- a/src/index.js
+++ b/src/index.js
@@ -114,6 +114,7 @@ class DependencyGraph {
       extractRequires: this._opts.extractRequires,
       transformCode: this._opts.transformCode,
       depGraphHelpers: this._helpers,
+      platforms: this._opts.platforms,
       assetDependencies: this._assetDependencies,
     });
 
@@ -123,6 +124,7 @@ class DependencyGraph {
       moduleCache: this._moduleCache,
       preferNativePlatform: this._opts.preferNativePlatform,
       helpers: this._helpers,
+      platforms: this._opts.platforms,
     });
 
     this._deprecatedAssetMap = new DeprecatedAssetMap({
@@ -134,6 +136,7 @@ class DependencyGraph {
       assetExts: this._opts.assetExts,
       activity: this._opts.activity,
       enabled: this._opts.enableAssetMap,
+      platforms: this._opts.platforms,
     });
 
     this._loading = Promise.all([
@@ -201,6 +204,7 @@ class DependencyGraph {
       const absPath = this._getAbsolutePath(entryPath);
       const req = new ResolutionRequest({
         platform,
+        platforms: this._opts.platforms,
         preferNativePlatform: this._opts.preferNativePlatform,
         entryPath: absPath,
         deprecatedAssetMap: this._deprecatedAssetMap,
@@ -229,10 +233,7 @@ class DependencyGraph {
 
   _getRequestPlatform(entryPath, platform) {
     if (platform == null) {
-      platform = getPlatformExtension(entryPath);
-      if (platform == null || this._opts.platforms.indexOf(platform) === -1) {
-        platform = null;
-      }
+      platform = getPlatformExtension(entryPath, this._opts.platforms);
     } else if (this._opts.platforms.indexOf(platform) === -1) {
       throw new Error('Unrecognized platform: ' + platform);
     }

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ class DependencyGraph {
       assetRoots_DEPRECATED: assetRoots_DEPRECATED || [],
       assetExts: assetExts || [],
       providesModuleNodeModules,
-      platforms: platforms || [],
+      platforms: new Set(platforms || []),
       preferNativePlatform: preferNativePlatform || false,
       extensions: extensions || ['js', 'json'],
       mocksPattern,
@@ -114,9 +114,8 @@ class DependencyGraph {
       extractRequires: this._opts.extractRequires,
       transformCode: this._opts.transformCode,
       depGraphHelpers: this._helpers,
-      platforms: this._opts.platforms,
       assetDependencies: this._assetDependencies,
-    });
+    }, this._opts.platfomrs);
 
     this._hasteMap = new HasteMap({
       fastfs: this._fastfs,
@@ -234,7 +233,7 @@ class DependencyGraph {
   _getRequestPlatform(entryPath, platform) {
     if (platform == null) {
       platform = getPlatformExtension(entryPath, this._opts.platforms);
-    } else if (this._opts.platforms.indexOf(platform) === -1) {
+    } else if (!this._opts.platforms.has(platform)) {
       throw new Error('Unrecognized platform: ' + platform);
     }
     return platform;

--- a/src/lib/__tests__/getPlatformExtension-test.js
+++ b/src/lib/__tests__/getPlatformExtension-test.js
@@ -22,4 +22,12 @@ describe('getPlatformExtension', function() {
     expect(getPlatformExtension('/b/c/a@1.5x.lol.png')).toBe(null);
     expect(getPlatformExtension('/b/c/a.lol.png')).toBe(null);
   });
+
+  it('should optionally accept supported platforms', function() {
+    expect(getPlatformExtension('a.ios.js', ['ios'])).toBe('ios');
+    expect(getPlatformExtension('a.android.js', ['android'])).toBe('android');
+    expect(getPlatformExtension('/b/c/a.ios.js', ['ios', 'android'])).toBe('ios');
+    expect(getPlatformExtension('a.ios.js', ['ubuntu'])).toBe(null);
+    expect(getPlatformExtension('a.ubuntu.js', ['ubuntu'])).toBe('ubuntu');
+  });
 });

--- a/src/lib/__tests__/getPlatformExtension-test.js
+++ b/src/lib/__tests__/getPlatformExtension-test.js
@@ -24,10 +24,10 @@ describe('getPlatformExtension', function() {
   });
 
   it('should optionally accept supported platforms', function() {
-    expect(getPlatformExtension('a.ios.js', ['ios'])).toBe('ios');
-    expect(getPlatformExtension('a.android.js', ['android'])).toBe('android');
-    expect(getPlatformExtension('/b/c/a.ios.js', ['ios', 'android'])).toBe('ios');
-    expect(getPlatformExtension('a.ios.js', ['ubuntu'])).toBe(null);
-    expect(getPlatformExtension('a.ubuntu.js', ['ubuntu'])).toBe('ubuntu');
+    expect(getPlatformExtension('a.ios.js', new Set(['ios']))).toBe('ios');
+    expect(getPlatformExtension('a.android.js', new Set(['android']))).toBe('android');
+    expect(getPlatformExtension('/b/c/a.ios.js', new Set(['ios', 'android']))).toBe('ios');
+    expect(getPlatformExtension('a.ios.js', new Set(['ubuntu']))).toBe(null);
+    expect(getPlatformExtension('a.ubuntu.js', new Set(['ubuntu']))).toBe('ubuntu');
   });
 });

--- a/src/lib/getAssetDataFromName.js
+++ b/src/lib/getAssetDataFromName.js
@@ -11,9 +11,9 @@
 const path = require('../fastpath');
 const getPlatformExtension = require('./getPlatformExtension');
 
-function getAssetDataFromName(filename) {
+function getAssetDataFromName(filename, platforms) {
   const ext = path.extname(filename);
-  const platformExt = getPlatformExtension(filename);
+  const platformExt = getPlatformExtension(filename, platforms);
 
   let pattern = '@([\\d\\.]+)x';
   if (platformExt != null) {

--- a/src/lib/getPlatformExtension.js
+++ b/src/lib/getPlatformExtension.js
@@ -8,21 +8,21 @@
  */
 'use strict';
 
-const SUPPORTED_PLATFORM_EXTS = {
-  android: true,
-  ios: true,
-  web: true,
-};
+const SUPPORTED_PLATFORM_EXTS = [
+  'android',
+  'ios',
+  'web',
+];
 
 // Extract platform extension: index.ios.js -> ios
-function getPlatformExtension(file) {
+function getPlatformExtension(file, platforms = SUPPORTED_PLATFORM_EXTS) {
   const last = file.lastIndexOf('.');
   const secondToLast = file.lastIndexOf('.', last - 1);
   if (secondToLast === -1) {
     return null;
   }
   const platform = file.substring(secondToLast + 1, last);
-  return SUPPORTED_PLATFORM_EXTS[platform] ? platform : null;
+  return platforms.indexOf(platform) !== -1 ? platform : null;
 }
 
 module.exports = getPlatformExtension;

--- a/src/lib/getPlatformExtension.js
+++ b/src/lib/getPlatformExtension.js
@@ -8,11 +8,11 @@
  */
 'use strict';
 
-const SUPPORTED_PLATFORM_EXTS = [
+const SUPPORTED_PLATFORM_EXTS = new Set([
   'android',
   'ios',
   'web',
-];
+]);
 
 // Extract platform extension: index.ios.js -> ios
 function getPlatformExtension(file, platforms = SUPPORTED_PLATFORM_EXTS) {
@@ -22,7 +22,7 @@ function getPlatformExtension(file, platforms = SUPPORTED_PLATFORM_EXTS) {
     return null;
   }
   const platform = file.substring(secondToLast + 1, last);
-  return platforms.indexOf(platform) !== -1 ? platform : null;
+  return platforms.has(platform) ? platform : null;
 }
 
 module.exports = getPlatformExtension;


### PR DESCRIPTION
Support extra platforms by enabling the list of verified platforms to be passed
to getPlatformExtension() via DependencyGraph.

Note: As the platforms passed to DependencyGraph become the de facto supported platforms, any platform not in the list is not recognised, and so assigned to the generic set. This is the reason for the change to DependencyGraph-test.js.
