### PR TITLE
Print stack trace for errors while persisting cache

### DIFF
--- a/src/Cache/index.js
+++ b/src/Cache/index.js
@@ -154,7 +154,10 @@ class Cache {
         });
         return denodeify(fs.writeFile)(cacheFilepath, JSON.stringify(json));
       })
-      .catch(e => console.error('Error while persisting cache:', e.message))
+      .catch(e => console.error(
+        '[node-haste] Encountered an error while persisting cache:\n%s',
+        e.stack.split('\n').map(line => '> ' + line).join('\n')
+      ))
       .then(() => {
         this._persisting = null;
         return true;


### PR DESCRIPTION
Makes a couple improvements to the error reporting when persisting the cache.

- Print the entire error stack (which typically includes the error message).
- Print `[node-haste]` so that it's more obvious who is responsible for printing this error.

I've tested this with `react-native` by making a Babel transform throw an expected error.