### PR TITLE
Timeout error raised by FileWatcher is silently swallowed

### DIFF
--- a/src/FileWatcher/index.js
+++ b/src/FileWatcher/index.js
@@ -13,7 +13,7 @@ const denodeify = require('denodeify');
 const sane = require('sane');
 const execSync = require('child_process').execSync;
 
-const MAX_WAIT_TIME = 120000;
+const MAX_WAIT_TIME = 10*60*1000;  // 10mins
 
 const detectWatcherClass = () => {
   try {
@@ -45,13 +45,20 @@ class FileWatcher extends EventEmitter {
     this._loading = Promise.all(watcherPromises).then(watchers => {
       watchers.forEach((watcher, i) => {
         this._watcherByRoot[rootConfigs[i].dir] = watcher;
+/*      Why wait until the watcher is 'ready' to listen to the file-change events it emits?
+        Let's move this hook to the '_createWatcher' method        
         watcher.on(
           'all',
           // args = (type, filePath, root, stat)
           (...args) => this.emit('all', ...args)
         );
+*/
       });
       return watchers;
+    }).catch(function(e) {
+      // Mimic of 'done' method for ES6 promises
+      // We need to catch error due to MAX_WAIT_TIME timeout here or the error will be silently ignored!
+      setTimeout(function() { throw e; });
     });
   }
 
@@ -77,6 +84,8 @@ class FileWatcher extends EventEmitter {
   }
 
   _createWatcher(rootConfig) {
+    var _this = this;
+    
     const watcher = new WatcherClass(rootConfig.dir, {
       glob: rootConfig.globs,
       dot: false,
@@ -92,6 +101,13 @@ class FileWatcher extends EventEmitter {
         clearTimeout(rejectTimeout);
         resolve(watcher);
       });
+      
+      watcher.on(
+        'all',
+        // args = (type, filePath, root, stat)
+        (...args) => _this.emit('all', ...args)
+      );
+      
     });
   }
 
@@ -109,14 +125,17 @@ class FileWatcher extends EventEmitter {
 
 function timeoutMessage(Watcher) {
   const lines = [
-    'Watcher took too long to load (' + Watcher.name + ')',
+    'File watcher took too long to load (Library being used: ' + Watcher.name + ')',
   ];
   if (Watcher === sane.WatchmanWatcher) {
     lines.push(
       'Try running `watchman version` from your terminal',
       'https://facebook.github.io/watchman/docs/troubleshooting.html',
     );
+  } else {
+    lines.push('The current library being used by the file watcher is NodeWatcher. We recommend you install Watchman on your system (http://facebook.github.io/watchman/) and run the app again to check if file crawling runs faster then.');
   }
+  lines.push('You may also increase the value of the MAX_WAIT_TIME timeout variable located in '+__filename+'\n');
   return lines.join('\n');
 }
 


### PR DESCRIPTION
If the MAX_WAIT_TIME timeout is reached, the error that is thrown by
FileWatcher is swallowed by the _loading Promise and thus it nevers gets
to the caller. This can be fixed by adding a 'done' block to this
promise.
Also, some of the messages that are displayed to the user should be a
bit more clearer.
