### PR TITLE
Add option to not cache source code.

### DIFF
--- a/src/Module.js
+++ b/src/Module.js
@@ -25,6 +25,7 @@ class Module {
     extractor = extractRequires,
     transformCode,
     depGraphHelpers,
+    options,
   }) {
     if (!isAbsolutePath(file)) {
       throw new Error('Expected file to be absolute path but got ' + file);
@@ -39,6 +40,7 @@ class Module {
     this._extractor = extractor;
     this._transformCode = transformCode;
     this._depGraphHelpers = depGraphHelpers;
+    this._options = options;
   }
 
   isHaste() {
@@ -90,7 +92,7 @@ class Module {
   }
 
   getDependencies(transformOptions) {
-    return this.read(transformOptions).then(data => data.dependencies);
+    return this.read(transformOptions).then(({dependencies}) => dependencies);
   }
 
   invalidate() {
@@ -149,7 +151,11 @@ class Module {
               code,
               dependencies = extern ? [] : this._extractor(code).deps.sync,
             } = result;
-            return {...result, dependencies, id, source};
+            if (this._options.cacheTransformResults) {
+              return {...result, dependencies, id, source};
+            } else {
+              return {dependencies};
+            }
           });
         });
       }

--- a/src/ModuleCache.js
+++ b/src/ModuleCache.js
@@ -24,6 +24,7 @@ class ModuleCache {
     this._transformCode = transformCode;
     this._depGraphHelpers = depGraphHelpers;
     this._assetDependencies = assetDependencies;
+    this._packageModuleMap = new WeakMap();
 
     fastfs.on('change', this._processFileChange.bind(this));
   }
@@ -72,22 +73,21 @@ class ModuleCache {
   }
 
   getPackageForModule(module) {
-    // TODO(amasad): use ES6 Map.
-    if (module.__package) {
-      if (this._packageCache[module.__package]) {
-        return this._packageCache[module.__package];
+    if (this._packageModuleMap.has(module)) {
+      const packagePath = this._packageModuleMap.get(module);
+      if (this._packageCache[packagePath]) {
+        return this._packageCache[packagePath];
       } else {
-        delete module.__package;
+        this._packageModuleMap.delete(module);
       }
     }
 
     const packagePath = this._fastfs.closest(module.path, 'package.json');
-
     if (!packagePath) {
       return null;
     }
 
-    module.__package = packagePath;
+    this._packageModuleMap.set(module, packagePath);
     return this.getPackage(packagePath);
   }
 

--- a/src/ModuleCache.js
+++ b/src/ModuleCache.js
@@ -15,6 +15,7 @@ class ModuleCache {
     transformCode,
     depGraphHelpers,
     assetDependencies,
+    moduleOptions,
   }) {
     this._moduleCache = Object.create(null);
     this._packageCache = Object.create(null);
@@ -24,6 +25,7 @@ class ModuleCache {
     this._transformCode = transformCode;
     this._depGraphHelpers = depGraphHelpers;
     this._assetDependencies = assetDependencies;
+    this._moduleOptions = moduleOptions;
     this._packageModuleMap = new WeakMap();
 
     fastfs.on('change', this._processFileChange.bind(this));
@@ -39,6 +41,7 @@ class ModuleCache {
         extractor: this._extractRequires,
         transformCode: this._transformCode,
         depGraphHelpers: this._depGraphHelpers,
+        options: this._moduleOptions,
       });
     }
     return this._moduleCache[filePath];

--- a/src/__tests__/Module-test.js
+++ b/src/__tests__/Module-test.js
@@ -64,6 +64,9 @@ describe('Module', () => {
 
   const createModule = (options) =>
     new Module({
+      options: {
+        cacheTransformResults: true,
+      },
       ...options,
       cache,
       fastfs,
@@ -368,6 +371,28 @@ describe('Module', () => {
 
       return module.read().then((result) => {
         expect(result).toEqual(jasmine.objectContaining(mockedResult));
+      });
+    });
+
+    pit('does not store anything but dependencies if the `cacheTransformResults` option is disabled', () => {
+      const mockedResult = {
+        code: exampleCode,
+        arbitrary: 'arbitrary',
+        dependencies: ['foo', 'bar'],
+        dependencyOffsets: [12, 764],
+        map: {version: 3},
+        subObject: {foo: 'bar'},
+      };
+      transformCode.mockReturnValue(Promise.resolve(mockedResult));
+      const module = createModule({transformCode, options: {
+        cacheTransformResults: false,
+      }});
+
+      return module.read().then((result) => {
+        console.log(result);
+        expect(result).toEqual({
+          dependencies: ['foo', 'bar'],
+        });
       });
     });
 

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,7 @@ class DependencyGraph {
     shouldThrowOnUnresolvedErrors = () => true,
     enableAssetMap,
     assetDependencies,
+    moduleOptions,
   }) {
     this._opts = {
       activity: activity || defaultActivity,
@@ -72,6 +73,9 @@ class DependencyGraph {
       transformCode,
       shouldThrowOnUnresolvedErrors,
       enableAssetMap: enableAssetMap || true,
+      moduleOptions: moduleOptions || {
+        cacheTransformResults: true,
+      },
     };
     this._cache = cache;
     this._assetDependencies = assetDependencies;
@@ -115,6 +119,7 @@ class DependencyGraph {
       transformCode: this._opts.transformCode,
       depGraphHelpers: this._helpers,
       assetDependencies: this._assetDependencies,
+      moduleOptions: this._opts.moduleOptions,
     });
 
     this._hasteMap = new HasteMap({


### PR DESCRIPTION
For some repositories it is not possible to store (or `JSON.stringify`) every file's source code and transformed output. Node.js will actually run out of memory and crash.

Some clients of node-haste might not need this at all. I made the least invasive change I could – add an option that determines what should be cached for a module. It is by default enabled, so a new release of node-haste should be fully backwards compatible.

Later we may have to implement a better way of caching transformed files. We might want to do what Jest does and create one output file per input file. In the meantime, this will suffice :)
