### PR TITLE
Add ability to grab multiple asset files using a wildcard (*)

### DIFF
--- a/src/DependencyGraph/DependencyGraphHelpers.js
+++ b/src/DependencyGraph/DependencyGraphHelpers.js
@@ -42,6 +42,10 @@ class DependencyGraphHelpers {
   extname(name) {
     return path.extname(name).substr(1);
   }
+
+  isGlob(file) {
+    return file.indexOf('*') !== -1;
+  }
 }
 
 module.exports = DependencyGraphHelpers;

--- a/src/DependencyGraph/ResolutionRequest.js
+++ b/src/DependencyGraph/ResolutionRequest.js
@@ -375,7 +375,7 @@ class ResolutionRequest {
 
   _loadAsFile(potentialModulePath, fromModule, toModule) {
     return Promise.resolve().then(() => {
-      if (this._helpers.isAssetFile(potentialModulePath)) {
+      if (this._helpers.isAssetFile(potentialModulePath) && !this._helpers.isGlob(potentialModulePath)) {
         const dirname = path.dirname(potentialModulePath);
         if (!this._fastfs.dirExists(dirname)) {
           throw new UnableToResolveError(
@@ -403,6 +403,10 @@ class ResolutionRequest {
         if (assetFile) {
           return this._moduleCache.getAssetModule(assetFile);
         }
+      }
+
+      if (this._helpers.isGlob(potentialModulePath)) {
+        return this._moduleCache.getGlobModule(potentialModulePath);
       }
 
       let file;

--- a/src/GlobModule.js
+++ b/src/GlobModule.js
@@ -45,14 +45,15 @@ class GlobModule extends Module {
 
   read(transformOptions) {
     const [, dir, file] = this.path.match(/(.*)\/([^/]+)$/);
-    const pattern = RegExp.escape(file).replace('\\*', '\/([^/.]+)') + '$';
+    const pattern = '^' + RegExp.escape(file).replace('\\*', '([^/.]+)') + '$';
+    const filenamePattern = /\/([^/.]+).[^/.]+$/
     const matches = this._fastfs.matches(dir, pattern);
     const dependencies = matches.map(x => {
       return '.' + x.slice(dir.length);
     });
 
     const source = dependencies.map(name => {
-      const [, match] = name.match(pattern);
+      const [, match] = name.match(filenamePattern);
       return `import ${match} from '${name}';\nexport {${match}}`;
     })
     .join('\n');

--- a/src/GlobModule.js
+++ b/src/GlobModule.js
@@ -30,7 +30,7 @@ class GlobModule extends Module {
   }
 
   getName() {
-    Promise.resolve(this.path);
+    return Promise.resolve(this.path);
   }
 
   getPackage() {
@@ -46,17 +46,21 @@ class GlobModule extends Module {
   read(transformOptions) {
     const [, dir, file] = this.path.match(/(.*)\/([^/]+)$/);
     const pattern = '^' + RegExp.escape(file).replace('\\*', '([^/.]+)') + '$';
-    const filenamePattern = /\/([^/.]+).[^/.]+$/
+    const filenamePattern = /\/([a-zA-Z][^/.]*).[^/.]+$/
     const matches = this._fastfs.matches(dir, pattern);
     const dependencies = matches.map(x => {
       return '.' + x.slice(dir.length);
     });
 
     const source = dependencies.map(name => {
-      const [, match] = name.match(filenamePattern);
-      return `import ${match} from '${name}';\nexport {${match}}`;
+      const match = name.match(filenamePattern);
+      if (match) {
+        return `import ${match[1]} from '${name}';\nexport {${match[1]}}\n`;
+      } else {
+        return ``;
+      }
     })
-    .join('\n');
+    .join('');
 
     const transformCode = this._transformCode;
     const codePromise = transformCode
@@ -69,7 +73,7 @@ class GlobModule extends Module {
         source,
         id: undefined,
       };
-    })
+    });
   }
 
   hash() {

--- a/src/GlobModule.js
+++ b/src/GlobModule.js
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+const path = require('./fastpath');
+const Module = require('./Module');
+
+class GlobModule extends Module {
+
+  constructor(...args) {
+    super(...args);
+  }
+
+  isHaste() {
+    return Promise.resolve(false);
+  }
+
+  getCode(transformOptions) {
+    return this.read(transformOptions).then(({code}) => code);
+  }
+
+  getMap(transformOptions) {
+    return Promise.resolve(null);
+  }
+
+  getName() {
+    Promise.resolve(this.path);
+  }
+
+  getPackage() {
+    return null;
+  }
+
+  getDependencies(transformOptions) {
+    return this.read(transformOptions).then(({dependencies}) => dependencies);
+  }
+
+  invalidate() {}
+
+  read(transformOptions) {
+    const [, dir, file] = this.path.match(/(.*)\/([^/]+)$/);
+    const pattern = RegExp.escape(file).replace('\\*', '\/([^/.]+)') + '$';
+    const matches = this._fastfs.matches(dir, pattern);
+    const dependencies = matches.map(x => {
+      return '.' + x.slice(dir.length);
+    });
+
+    const source = dependencies.map(name => {
+      const [, match] = name.match(pattern);
+      return `import ${match} from '${name}';\nexport {${match}}`;
+    })
+    .join('\n');
+
+    const transformCode = this._transformCode;
+    const codePromise = transformCode
+        ? transformCode(this, source, transformOptions)
+        : Promise.resolve({code: source});
+
+    return codePromise.then(result => {
+      return {
+        ...result,
+        source,
+        id: undefined,
+      };
+    })
+  }
+
+  hash() {
+    return `Module : ${this.path}`;
+  }
+
+  isJSON() {
+    return false;
+  }
+
+  isAsset() {
+    return false;
+  }
+
+  isPolyfill() {
+    return false;
+  }
+
+  isAsset_DEPRECATED() {
+    return false;
+  }
+
+  toJSON() {
+    return {
+      hash: this.hash(),
+      isJSON: this.isJSON(),
+      isAsset: this.isAsset(),
+      isAsset_DEPRECATED: this.isAsset_DEPRECATED(),
+      type: this.type,
+      path: this.path,
+    };
+  }
+}
+
+module.exports = GlobModule;

--- a/src/ModuleCache.js
+++ b/src/ModuleCache.js
@@ -3,6 +3,7 @@
 const AssetModule = require('./AssetModule');
 const Package = require('./Package');
 const Module = require('./Module');
+const GlobModule = require('./GlobModule');
 const Polyfill = require('./Polyfill');
 const path = require('./fastpath');
 
@@ -49,6 +50,22 @@ class ModuleCache {
 
   getAllModules() {
     return this._moduleCache;
+  }
+
+  getGlobModule(filePath) {
+    if (!this._moduleCache[filePath]) {
+      this._moduleCache[filePath] = new GlobModule({
+        file: filePath,
+        fastfs: this._fastfs,
+        moduleCache: this,
+        cache: this._cache,
+        extractor: this._extractRequires,
+        transformCode: this._transformCode,
+        depGraphHelpers: this._depGraphHelpers,
+        options: this._moduleOptions,
+      });
+    }
+    return this._moduleCache[filePath];
   }
 
   getAssetModule(filePath) {


### PR DESCRIPTION
No idea if you like this, or want to bother about, but I needed I myself so I figured, why not :D

I didn’t want to add every single file of my animations using it’s own `require` or `import` statement, and I don’t like managing my assets in Xcode either (I don’t even know how to do so in Android)

So I made it so you can put a wildcard (*) at the end (with an extension) and it will take all the files in the directory and make them into a es6 module.

If you like the idea in the upstream version, I’ll add tests and stuff :)
