### PR TITLE
Add support for additional node modules

### DIFF
--- a/src/DependencyGraph/ResolutionRequest.js
+++ b/src/DependencyGraph/ResolutionRequest.js
@@ -35,6 +35,7 @@ class ResolutionRequest {
     moduleCache,
     fastfs,
     shouldThrowOnUnresolvedErrors,
+    extraNodeModules,
   }) {
     this._platform = platform;
     this._preferNativePlatform = preferNativePlatform;
@@ -45,6 +46,7 @@ class ResolutionRequest {
     this._moduleCache = moduleCache;
     this._fastfs = fastfs;
     this._shouldThrowOnUnresolvedErrors = shouldThrowOnUnresolvedErrors;
+    this._extraNodeModules = extraNodeModules;
     this._resetResolutionCache();
   }
 
@@ -351,6 +353,14 @@ class ResolutionRequest {
             searchQueue.push(
               path.join(currDir, 'node_modules', realModuleName)
             );
+          }
+
+          if (this._extraNodeModules) {
+            const bits = toModuleName.split('/');
+            const packageName = bits[0];
+            if (this._extraNodeModules[packageName]) {
+              searchQueue.push(this._extraNodeModules[packageName]);
+            }
           }
 
           let p = Promise.reject(new UnableToResolveError(

--- a/src/__tests__/DependencyGraph-test.js
+++ b/src/__tests__/DependencyGraph-test.js
@@ -2338,6 +2338,113 @@ describe('DependencyGraph', function() {
           ]);
       });
     });
+
+    pit('should fall back to `extraNodeModules`', () => {
+      const root = '/root';
+      fs.__setMockFilesystem({
+        [root.slice(1)]: {
+          'index.js': 'require("./foo")',
+          'foo': {
+            'index.js': 'require("bar")',
+          },
+          'provides-bar': {
+            'package.json': '{"main": "lib/bar.js"}',
+            'lib': {
+              'bar.js': '',
+            },
+          },
+        },
+      });
+
+      var dgraph = new DependencyGraph({
+        ...defaults,
+        roots: [root],
+        extraNodeModules: {
+          'bar': root + '/provides-bar',
+        },
+      });
+
+      return getOrderedDependenciesAsJSON(dgraph, '/root/index.js').then(deps => {
+        expect(deps)
+          .toEqual([
+            {
+              id: '/root/index.js',
+              path: '/root/index.js',
+              dependencies: ['./foo'],
+              isAsset: false,
+              isAsset_DEPRECATED: false,
+              isJSON: false,
+              isPolyfill: false,
+              resolution: undefined,
+            },
+            {
+              id: '/root/foo/index.js',
+              path: '/root/foo/index.js',
+              dependencies: ['bar'],
+              isAsset: false,
+              isAsset_DEPRECATED: false,
+              isJSON: false,
+              isPolyfill: false,
+              resolution: undefined,
+            },
+            {
+              id: '/root/provides-bar/lib/bar.js',
+              path: '/root/provides-bar/lib/bar.js',
+              dependencies: [],
+              isAsset: false,
+              isAsset_DEPRECATED: false,
+              isJSON: false,
+              isPolyfill: false,
+              resolution: undefined,
+            },
+          ]);
+      });
+    });
+
+    pit('should only use `extraNodeModules` after checking all possible filesystem locations', () => {
+      const root = '/root';
+      fs.__setMockFilesystem({
+        [root.slice(1)]: {
+          'index.js': 'require("bar")',
+          'node_modules': { 'bar.js': '' },
+          'provides-bar': { 'index.js': '' },
+        },
+      });
+
+      var dgraph = new DependencyGraph({
+        ...defaults,
+        roots: [root],
+        extraNodeModules: {
+          'bar': root + '/provides-bar',
+        },
+      });
+
+      return getOrderedDependenciesAsJSON(dgraph, '/root/index.js').then(deps => {
+        expect(deps)
+          .toEqual([
+            {
+              id: '/root/index.js',
+              path: '/root/index.js',
+              dependencies: ['bar'],
+              isAsset: false,
+              isAsset_DEPRECATED: false,
+              isJSON: false,
+              isPolyfill: false,
+              resolution: undefined,
+            },
+            {
+              id: '/root/node_modules/bar.js',
+              path: '/root/node_modules/bar.js',
+              dependencies: [],
+              isAsset: false,
+              isAsset_DEPRECATED: false,
+              isJSON: false,
+              isPolyfill: false,
+              resolution: undefined,
+            },
+          ]);
+      });
+    });
   });
 
   describe('get sync dependencies (win32)', function() {

--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,7 @@ class DependencyGraph {
     enableAssetMap,
     assetDependencies,
     moduleOptions,
+    extraNodeModules,
   }) {
     this._opts = {
       activity: activity || defaultActivity,
@@ -76,6 +77,7 @@ class DependencyGraph {
       moduleOptions: moduleOptions || {
         cacheTransformResults: true,
       },
+      extraNodeModules,
     };
     this._cache = cache;
     this._assetDependencies = assetDependencies;
@@ -214,6 +216,7 @@ class DependencyGraph {
         moduleCache: this._moduleCache,
         fastfs: this._fastfs,
         shouldThrowOnUnresolvedErrors: this._opts.shouldThrowOnUnresolvedErrors,
+        extraNodeModules: this._opts.extraNodeModules,
       });
 
       const response = new ResolutionResponse({transformOptions});


### PR DESCRIPTION
This adds support for file system locations that are supposed to be discoverable as global node modules.

It’s similar to the `NODE_PATH` environment variable, but provides a mapping from module names to file system locations.

This is necessary for fb-internal use cases.