### PR TITLE
Update getPlatformExtension.js

### DIFF
--- a/src/lib/getPlatformExtension.js
+++ b/src/lib/getPlatformExtension.js
@@ -12,6 +12,7 @@ const SUPPORTED_PLATFORM_EXTS = {
   android: true,
   ios: true,
   web: true,
+  windows: true,
 };
 
 // Extract platform extension: index.ios.js -> ios


### PR DESCRIPTION
Adds windows as a supported platform.  Without this change, 'windows' is treated as the generic platform, which means we cannot override other generic dependencies.