### PR TITLE
Made all FS async operations timeoutable

### DIFF
--- a/src/Cache/__tests__/Cache-test.js
+++ b/src/Cache/__tests__/Cache-test.js
@@ -10,6 +10,7 @@
 
 jest
   .dontMock('absolute-path')
+  .dontMock('../../lib/timeoutableAsync')
   .dontMock('../');
 
 jest

--- a/src/__tests__/Module-test.js
+++ b/src/__tests__/Module-test.js
@@ -15,6 +15,7 @@ jest
   .dontMock('../lib/extractRequires')
   .dontMock('../lib/replacePatterns')
   .dontMock('../DependencyGraph/docblock')
+  .dontMock('../lib/timeoutableAsync')
   .dontMock('../Module');
 
 jest

--- a/src/crawlers/node.js
+++ b/src/crawlers/node.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const denodeify = require('denodeify');
 const debug = require('debug')('ReactNativePackager:DependencyGraph');
 const fs = require('graceful-fs');
 const path = require('../fastpath');
 
-const readDir = denodeify(fs.readdir);
-const stat = denodeify(fs.stat);
+const timeoutableAsync = require('../lib/timeoutableAsync');
+const readDir = timeoutableAsync.timeoutableDenodeify(fs.readdir, 5000);
+const stat = timeoutableAsync.timeoutableDenodeify(fs.stat, 5000);
 
 function nodeRecReadDir(roots, {ignore, exts}) {
   const queue = roots.slice();

--- a/src/fastfs.js
+++ b/src/fastfs.js
@@ -8,14 +8,16 @@
  */
 'use strict';
 
-const denodeify = require('denodeify');
 const {EventEmitter} = require('events');
 
 const fs = require('graceful-fs');
 const path = require('./fastpath');
+const timeoutableAsync = require('./lib/timeoutableAsync');
 
-const readFile = denodeify(fs.readFile);
-const stat = denodeify(fs.stat);
+const readFile = timeoutableAsync.timeoutableDenodeify(fs.readFile, 5000);
+const stat = timeoutableAsync.timeoutableDenodeify(fs.stat, 5000);
+const openAsync = timeoutableAsync.timeoutableFunction(fs.open, 5000);
+const readAsync = timeoutableAsync.timeoutableFunction(fs.read, 5000);
 
 const NOT_FOUND_IN_ROOTS = 'NotFoundInRootsError';
 
@@ -305,7 +307,7 @@ class File {
 
 function readWhile(filePath, predicate) {
   return new Promise((resolve, reject) => {
-    fs.open(filePath, 'r', (openError, fd) => {
+    openAsync(filePath, 'r', (openError, fd) => {
       if (openError) {
         reject(openError);
         return;
@@ -328,7 +330,7 @@ function readWhile(filePath, predicate) {
 }
 
 function read(fd, buffer, callback) {
-  fs.read(fd, buffer, 0, buffer.length, -1, callback);
+  readAsync(fd, buffer, 0, buffer.length, -1, callback);
 }
 
 function close(fd, error, result, complete, callback) {

--- a/src/lib/__tests__/timeoutableAsync.js
+++ b/src/lib/__tests__/timeoutableAsync.js
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+jest.dontMock('../timeoutableAsync');
+
+const timeoutableAsync = require('../timeoutableAsync');
+
+describe('timeoutableAsync', function() {
+  
+  describe('.timeoutableDenodeify()', function() {
+  
+    pit('should reject promise after timeout', function() {
+      function asyncFunc(callback) {
+        setTimeout(callback, 600, null, 'Success');
+      }
+      const reject = jest.fn();
+      const res = timeoutableAsync.timeoutableDenodeify(asyncFunc, 500)()
+        .then(null, reject)
+        .then(() => {
+          expect(reject).toBeCalledWith('operation timeout');
+        });
+      jest.runAllTimers();
+      return res;
+    });
+
+    pit('should reject promise if async function finsihes with error first', 
+    function() {
+      function asyncFunc(callback) {
+        setTimeout(callback, 300, 'Error in callback');
+      }
+      const reject = jest.fn();
+      const res = timeoutableAsync.timeoutableDenodeify(asyncFunc, 500)()
+        .then(null, reject)
+        .then(() => {
+          expect(reject).toBeCalledWith('Error in callback');
+        });
+      jest.runAllTimers();
+      return res;
+    });
+    
+    pit('should resolve promise if async function finsihes with first without errors', 
+    function() {
+      function asyncFunc(callback) {
+        setTimeout(callback, 300, null, 'Success');
+      }
+      const resolve = jest.fn();
+      const reject = jest.fn();
+      const res = timeoutableAsync.timeoutableDenodeify(asyncFunc, 500)()
+        .then(resolve, reject)
+        .then(() => {
+          expect(reject).not.toBeCalled();
+          expect(resolve).toBeCalledWith('Success');
+        });
+      jest.runAllTimers();
+      return res;
+    });
+    
+  });
+  
+  describe('.timeoutableFunction()', function() {
+  
+    it('should call error callback after timeout', function(done) {
+      function asyncFunc(param1, param2, callback) {
+        expect(param1).toBe('First Param');
+        expect(param2).toBe('Second Param');
+        setTimeout(callback, 600, null, 'Success');
+      }
+      const timeoutable = timeoutableAsync.timeoutableFunction(asyncFunc, 500);
+      timeoutable('First Param', 'Second Param', (error, response) => {
+        expect(error).toBe('operation timeout');
+        done();
+      });
+      jest.runAllTimers();
+    });
+
+    it('should call error callback if async returns error before timeout', 
+    function(done) {
+      function asyncFunc(callback) {
+        setTimeout(callback, 300, 'Error');
+      }
+      const timeoutable = timeoutableAsync.timeoutableFunction(asyncFunc, 500);
+      timeoutable((error, response) => {
+        expect(error).toBe('Error');
+        done();
+      });
+      jest.runAllTimers();
+    });
+
+    it('should call success callback if async returns success before timeout', 
+    function(done) {
+      function asyncFunc(callback) {
+        setTimeout(callback, 300, null, 'Success response 1', 'Success response 2');
+      }
+      const timeoutable = timeoutableAsync.timeoutableFunction(asyncFunc, 500);
+      timeoutable((error, response1, response2) => {
+        expect(error).toBe(null);
+        expect(response1).toBe('Success response 1');
+        expect(response2).toBe('Success response 2');
+        done();
+      });
+      jest.runAllTimers();
+    });
+    
+  });
+});

--- a/src/lib/timeoutableAsync.js
+++ b/src/lib/timeoutableAsync.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const denodeify = require('denodeify');
+
+const createTimeoutPromise = (timeout) => new Promise((resolve, reject) => {
+  setTimeout(reject, timeout, 'operation timeout');
+});
+
+function race(entries) {
+  return new Promise(function(resolve, reject) {
+    const length = entries.length;
+    for (let i = 0; i < length; i++) {
+      Promise.resolve(entries[i]).then(resolve, reject);
+    }
+  });
+}
+
+function timeoutableDenodeify(asyncFunc, timeout) {
+  return function raceWrapper(...args) {
+    return race([
+      createTimeoutPromise(timeout),
+      denodeify(asyncFunc).apply(this, args),
+    ]);
+  };
+}
+
+function timeoutableFunction(asyncFunc, timeout) {
+  return function raceWrapper(...args) {
+    const callback = args[args.length - 1];
+    return race([
+      createTimeoutPromise(timeout),
+      new Promise((resolve, reject) => {
+        const asyncArgs = args.slice(0, args.length - 1).concat((...args) => {
+          const error = args[0];
+          error ? reject(error) : resolve(args.slice(1));
+        });
+        asyncFunc.apply(this, asyncArgs);
+      }),
+    ]).then(
+      (response) => {
+        callback.apply(this, [null, ...response]);
+      }, 
+      (error) => {
+        callback.call(this, error);
+      }, 
+    );
+  };
+}
+
+module.exports = {
+  timeoutableDenodeify,
+  timeoutableFunction,
+};


### PR DESCRIPTION
In large code bases we have problems of graceful-fs read/write operations to hang infinitely.
To mitigate the problem and to be able to find out the reason I implemented 5 seconds timeout for all those fs operations.

This is quite ad-hoc, I think it would be cleaner to introduce timeouts directly to graceful-fs library but I am follwoing David Aurelio's lead here.