### PR TITLE
Added ability to get modules from NODE_PATH if exists

### DIFF
--- a/src/DependencyGraph/ResolutionRequest.js
+++ b/src/DependencyGraph/ResolutionRequest.js
@@ -342,6 +342,11 @@ class ResolutionRequest {
           }
 
           const searchQueue = [];
+
+          if (process.env.NODE_PATH) {
+            searchQueue.push(path.join(process.env.NODE_PATH, realModuleName));
+          }
+
           for (let currDir = path.dirname(fromModule.path);
                currDir !== realPath.parse(fromModule.path).root;
                currDir = path.dirname(currDir)) {

--- a/src/DependencyGraph/ResolutionRequest.js
+++ b/src/DependencyGraph/ResolutionRequest.js
@@ -343,10 +343,6 @@ class ResolutionRequest {
 
           const searchQueue = [];
 
-          if (process.env.NODE_PATH) {
-            searchQueue.push(path.join(process.env.NODE_PATH, realModuleName));
-          }
-
           for (let currDir = path.dirname(fromModule.path);
                currDir !== realPath.parse(fromModule.path).root;
                currDir = path.dirname(currDir)) {
@@ -362,6 +358,10 @@ class ResolutionRequest {
               bits[0] = this._extraNodeModules[packageName];
               searchQueue.push(path.join.apply(path, bits));
             }
+          }
+
+          if (process.env.NODE_PATH) {
+            searchQueue.push(path.join(process.env.NODE_PATH, realModuleName));
           }
 
           let p = Promise.reject(new UnableToResolveError(


### PR DESCRIPTION
Node JS allows you to specify a NODE_PATH env variable, this allows you to require things from directories that are not in the project path.

We use this in our node projects and in React Native to tell it to get the modules from our_project/third_party/js. Now that react-native has react as a peer dependency we are running into issues where node-haste will only look for react in node_modules folders and miss out third_party/js completely.
