### PR TITLE
Add backticks into `require` parse

### DIFF
--- a/src/lib/__tests__/extractRequires-test.js
+++ b/src/lib/__tests__/extractRequires-test.js
@@ -18,11 +18,12 @@ describe('extractRequires', () => {
     const code = `
       import module1 from 'module1';
       const module2 = require('module2');
+      const module3 = require(\`module3\`);
     `;
 
     expect(extractRequires(code)).toEqual({
       code,
-      deps: {sync: ['module1', 'module2']},
+      deps: {sync: ['module1', 'module2', 'module3']},
     });
   });
 

--- a/src/lib/replacePatterns.js
+++ b/src/lib/replacePatterns.js
@@ -11,4 +11,4 @@
 
 exports.IMPORT_RE = /(\bimport\s+(?:[^'"]+\s+from\s+)??)(['"])([^'"]+)(\2)/g;
 exports.EXPORT_RE = /(\bexport\s+(?:[^'"]+\s+from\s+)??)(['"])([^'"]+)(\2)/g;
-exports.REQUIRE_RE = /(\brequire\s*?\(\s*?)(['"])([^'"]+)(\2\s*?\))/g;
+exports.REQUIRE_RE = /(\brequire\s*?\(\s*?)(['"`])([^'"`]+)(\2\s*?\))/g;


### PR DESCRIPTION
Fixes case when we use require with backticks:

Simple, this works:

```js
const heart        = require('./img/heart.png'),
```

This __not__ works:
```js
const heart        = require(`./img/heart.png`),
```

This PR adds assertion into existing testcase and modifies parsing regexp.